### PR TITLE
Define XOS App from Python (Simple, only native - no wasm yet)

### DIFF
--- a/python/run.py
+++ b/python/run.py
@@ -1,3 +1,14 @@
 import xos
 
-xos.run_game("ball", web=False, react_native=False)
+
+# run a rust compiled game with the game name here
+# xos.run_game("ball", web=False, react_native=False)
+
+class PyApp(xos.ApplicationBase):
+    def setup(self, width: int, height: int):
+        pass
+
+    def tick(self, width: int, height: int):
+        return [0, 100, 100, 255] * (width * height)  # RGBA black pixels
+
+xos.run_game(PyApp(), web=False, react_native=False)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod apps;
 pub mod engine;
 pub mod video;
 
+#[cfg(feature = "python")]
 mod py_engine;
 
 // --- Native startup ---

--- a/src/py_engine.rs
+++ b/src/py_engine.rs
@@ -1,0 +1,52 @@
+use pyo3::prelude::*;
+use pyo3::types::PyType;
+
+use crate::engine::Application;
+
+pub struct PyApplicationWrapper {
+    py_app: PyObject,
+}
+
+impl PyApplicationWrapper {
+    pub fn new(py_app: PyObject) -> Self {
+        Self { py_app }
+    }
+}
+
+impl Application for PyApplicationWrapper {
+    fn setup(&mut self, width: u32, height: u32) -> Result<(), String> {
+        Python::with_gil(|py| {
+            let app = self.py_app.as_ref(py);
+            app.call_method("setup", (width, height), None)
+                .map(|_| ())
+                .map_err(|e| format!("setup error: {:?}", e))
+        })
+    }
+
+    fn tick(&mut self, width: u32, height: u32) -> Vec<u8> {
+        Python::with_gil(|py| {
+            let app = self.py_app.as_ref(py);
+            match app.call_method("tick", (width, height), None) {
+                Ok(result) => result.extract::<Vec<u8>>().unwrap_or_default(),
+                Err(_) => vec![],
+            }
+        })
+    }
+}
+
+// Optional ergonomic base class
+#[pyclass(subclass)]
+pub struct ApplicationBase;
+
+#[pymethods]
+impl ApplicationBase {
+    #[new]
+    fn new() -> Self {
+        ApplicationBase
+    }
+
+    fn setup(&mut self, _width: u32, _height: u32) {}
+    fn tick(&mut self, _width: u32, _height: u32) -> Vec<u8> {
+        vec![]
+    }
+}


### PR DESCRIPTION
First look at being able to define an XOS app running from python ([youtube video here](https://youtu.be/5EGuPR9zoM0))! It only works for the standard runtime mode, not with wasm just yet (need to add some automatic bindings to communicate between the python process and the wasm compiled code running in the browser / ios).

The code looks something like this:

```python
import xos

class PyApp(xos.ApplicationBase):
    def setup(self, width: int, height: int):
        pass

    def tick(self, width: int, height: int):
       # just render a cyan screen :D
        return [0, 100, 100, 255] * (width * height)

xos.run_game(PyApp(), web=False, react_native=False)
```

https://github.com/user-attachments/assets/ad77a1db-08c6-4d3b-b6bc-702d053bfc6f


That part particularly might be challenging to get right, generalizeable, and extensible/maintainable. The key is that users who want to use `--web` or `--react-native` to run these experimental python applications with interlink between them shouldn't ever have to write http servers or rtc interconnects or anything that could complicate their development process.

Instead- they should literally look the exact same as the standard native method- just calling the bindings directly. So if we want to have `--web`/`--react-native` be just as seemless as the standard native methodology, we're going to probably have to design a robust auto-binding system for the input and outputs of these functions.

This also ties in with some future ideas for mesh networking and automatic P2P rank addressing between authenticated clients within an XOS network of nodes (personal devices like your IOS, browser tabs, mac os, etc.) being able to intercommunicate without any custom networking. Just seamless.