### PR TITLE
Python Camera!!!

### DIFF
--- a/python/eye_tracking_RL.py
+++ b/python/eye_tracking_RL.py
@@ -1,0 +1,54 @@
+import xospy
+import numpy as np
+import time
+
+class PyApp(xospy.ApplicationBase):
+    def setup(self, state):
+        xospy.video.webcam.init_camera()
+        self.last_time = time.time()
+        self.tick_count = 0
+
+    def tick(self, state):
+        self.tick_count += 1
+        now = time.time()
+        if now - self.last_time >= 1.0:
+            print(f"TPS: {self.tick_count}")
+            self.tick_count = 0
+            self.last_time = now
+
+        width, height = state.frame.width, state.frame.height
+        mv = memoryview(state.frame.buffer)
+        frame = np.frombuffer(mv, dtype=np.uint8).reshape((height, width, 4))
+        frame[:] = 0  # fill with black initially
+
+        # Get webcam frame as RGB and shape
+        cam_bytes = xospy.video.webcam.get_frame()
+        cam_array = np.frombuffer(cam_bytes, dtype=np.uint8)
+        cam_array = cam_array.reshape((-1, 3))  # RGB
+
+        # Infer webcam resolution (you can also get this from get_resolution())
+        cam_h = int((len(cam_array) / 3) ** 0.5)
+        cam_w = len(cam_array) // cam_h
+        cam_array = cam_array[:cam_h * cam_w].reshape((cam_h, cam_w, 3))
+
+        # Resize webcam frame to fit inside main frame, maintaining aspect ratio
+        scale = min(width / cam_w, height / cam_h)
+        new_w = int(cam_w * scale)
+        new_h = int(cam_h * scale)
+
+        # Downscale or upscale with nearest neighbor manually (no PIL)
+        y_indices = (np.linspace(0, cam_h - 1, new_h)).astype(int)
+        x_indices = (np.linspace(0, cam_w - 1, new_w)).astype(int)
+        resized_cam = cam_array[y_indices[:, None], x_indices]  # shape (new_h, new_w, 3)
+
+        # Compute offsets to center
+        y_off = (height - new_h) // 2
+        x_off = (width - new_w) // 2
+
+        # Paste resized camera image into the center of the frame
+        frame[y_off:y_off+new_h, x_off:x_off+new_w, :3] = resized_cam
+        frame[y_off:y_off+new_h, x_off:x_off+new_w, 3] = 255  # set alpha
+
+        return frame
+
+xospy.run_py_game(PyApp(), web=False, react_native=False)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,11 +172,21 @@ fn run_py_game(py_app: PyObject, web: bool, react_native: bool) {
 
 #[cfg(feature = "python")]
 #[pymodule]
-fn xospy(_py: Python, m: &PyModule) -> PyResult<()> {
+fn xospy(py: Python, m: &PyModule) -> PyResult<()> {
+    // Core Python classes/functions
     m.add_class::<py_engine::ApplicationBase>()?;
     m.add_function(wrap_pyfunction!(run_native_game, m)?)?;
     m.add_function(wrap_pyfunction!(run_py_game, m)?)?;
     m.add_function(wrap_pyfunction!(version_py, m)?)?;
+
+    // ─── Add video.webcam ───────────────────────────────────────────────────────
+    let video_module = PyModule::new(py, "video")?;
+    let webcam_module = PyModule::new(py, "webcam")?;
+    crate::video::webcam::py_webcam::webcam(py, webcam_module)?;
+    video_module.add_submodule(webcam_module)?;
+    m.add_submodule(video_module)?;
+    // ───────────────────────────────────────────────────────────────────────────
+
     Ok(())
 }
 

--- a/src/video/webcam/mod.rs
+++ b/src/video/webcam/mod.rs
@@ -7,3 +7,7 @@ pub mod native_webcam;
 pub use wasm_webcam::*;
 #[cfg(not(target_arch = "wasm32"))]
 pub use native_webcam::*;
+
+#[cfg(feature = "python")]
+#[cfg(not(target_arch = "wasm32"))]
+pub mod py_webcam;

--- a/src/video/webcam/py_webcam.rs
+++ b/src/video/webcam/py_webcam.rs
@@ -13,13 +13,13 @@ pub fn webcam(py: Python, m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 
-#[pyfunction]
+#[pyfunction(name="init_camera")]
 fn init_camera_py() {
     #[cfg(not(target_arch = "wasm32"))]
     native_webcam::init_camera();
 }
 
-#[pyfunction]
+#[pyfunction(name="get_resolution")]
 fn get_resolution_py(py: Python) -> PyObject {
     #[cfg(not(target_arch = "wasm32"))]
     {
@@ -31,7 +31,7 @@ fn get_resolution_py(py: Python) -> PyObject {
     PyTuple::new(py, &[0u32, 0u32]).into()
 }
 
-#[pyfunction]
+#[pyfunction(name="get_frame")]
 fn get_frame_py(py: Python) -> PyObject {
     #[cfg(not(target_arch = "wasm32"))]
     {

--- a/src/video/webcam/py_webcam.rs
+++ b/src/video/webcam/py_webcam.rs
@@ -1,0 +1,44 @@
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyTuple};
+
+#[cfg(not(target_arch = "wasm32"))]
+use super::native_webcam;
+
+/// Python bindings for `xos::video::webcam`
+#[pymodule]
+pub fn webcam(py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(init_camera_py, m)?)?;
+    m.add_function(wrap_pyfunction!(get_resolution_py, m)?)?;
+    m.add_function(wrap_pyfunction!(get_frame_py, m)?)?;
+    Ok(())
+}
+
+#[pyfunction]
+fn init_camera_py() {
+    #[cfg(not(target_arch = "wasm32"))]
+    native_webcam::init_camera();
+}
+
+#[pyfunction]
+fn get_resolution_py(py: Python) -> PyObject {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let (w, h) = native_webcam::get_resolution();
+        PyTuple::new(py, &[w, h]).into()
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    PyTuple::new(py, &[0u32, 0u32]).into()
+}
+
+#[pyfunction]
+fn get_frame_py(py: Python) -> PyObject {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let buf = native_webcam::get_frame();
+        PyBytes::new(py, &buf).into()
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    PyBytes::new(py, &[]).into()
+}


### PR DESCRIPTION
You can now call these functions from within python!!!

```python
xospy.video.webcam.init_camera()
xospy.video.webcam.get_resolution()
xospy.video.webcam.get_frame()
```

This allows you to create a python app that:
1. Loads frames from the xos native camera INTO a python numpy array
2. Do whatever you want to the numpy array in native python
3. Render the camera back onto the xos native renderer!!! (only native support, wasm not done yet)

So this means we have a much simpler and easier library to read from the webcam! and it runs in ~30fps!!!!!!!

This is awesome... and it means that I can now do some really fun stuff 🗡️ 

Permalink to the exact code for this working is [here](https://github.com/xlateai/xos/blob/c3aa494a9c644cb9ba50fe14056a499cb0bc5a77/python/python_camera.py#L36) :D.