### PR TITLE
Wireframe + Text (and cursor styles)

### DIFF
--- a/src/apps/mod.rs
+++ b/src/apps/mod.rs
@@ -7,6 +7,7 @@ pub mod waveform;
 pub mod scroll;
 pub mod text;
 pub mod wireframe;
+pub mod wireframe_text;
 
 use crate::engine::Application;
 
@@ -21,6 +22,7 @@ pub fn get_app(name: &str) -> Option<Box<dyn Application>> {
         "scroll" => Some(Box::new(scroll::ScrollApp::new())),
         "text" => Some(Box::new(text::TextApp::new())),
         "wireframe" => Some(Box::new(wireframe::WireframeDemo::new())),
+        "wireframe_text" => Some(Box::new(wireframe_text::WireframeText::new())),
         _ => None,
     }
 }

--- a/src/apps/wireframe_text.rs
+++ b/src/apps/wireframe_text.rs
@@ -5,8 +5,8 @@ use crate::apps::text::geometric::GeometricText;
 use fontdue::{Font, FontSettings};
 
 tuneables! {
-    square_x: f32 = 0.4678812;
-    square_y: f32 = 0.6614094;
+    square_x: f32 = 0.42148933;
+    square_y: f32 = 0.5229107;
 }
 
 const BACKGROUND_COLOR: (u8, u8, u8) = (32, 32, 32);
@@ -84,18 +84,22 @@ impl WireframeText {
         let width = state.frame.width;
         let height = state.frame.height;
         self.text_engine.tick(tw as f32, th as f32);
-
+    
         for character in &self.text_engine.characters {
             let px = tx + character.x as i32;
             let py = ty + character.y as i32;
-
+    
             for y in 0..character.metrics.height {
                 for x in 0..character.metrics.width {
                     let val = character.bitmap[y * character.metrics.width + x];
-
+    
+                    if val == 0 {
+                        continue;
+                    }
+    
                     let sx = px + x as i32;
                     let sy = py + y as i32;
-
+    
                     if sx >= 0 && sx < width as i32 && sy >= 0 && sy < height as i32 {
                         let idx = ((sy as u32 * width + sx as u32) * 4) as usize;
                         buffer[idx + 0] = ((TEXT_COLOR.0 as u16 * val as u16) / 255) as u8;

--- a/src/apps/wireframe_text.rs
+++ b/src/apps/wireframe_text.rs
@@ -5,10 +5,10 @@ use crate::apps::text::geometric::GeometricText;
 use fontdue::{Font, FontSettings};
 
 tuneables! {
-    left_edge: f32 = 0.31168655;
-    right_edge: f32 = 0.72704995;
-    top_edge: f32 = 0.35551643;
-    bottom_edge: f32 = 0.61583114;
+    left_edge: f32 = 0.31286755;
+    right_edge: f32 = 0.6760411;
+    top_edge: f32 = 0.5608281;
+    bottom_edge: f32 = 0.9386236;
 }
 
 const BACKGROUND_COLOR: (u8, u8, u8) = (32, 32, 32);

--- a/src/apps/wireframe_text.rs
+++ b/src/apps/wireframe_text.rs
@@ -5,12 +5,10 @@ use crate::apps::text::geometric::GeometricText;
 use fontdue::{Font, FontSettings};
 
 tuneables! {
-    square_x: f32 = 0.5;
-    square_y: f32 = 0.5;
-    left_edge: f32 = 0.19982228;
-    right_edge: f32 = 0.9262413;
-    top_edge: f32 = 0.3;
-    bottom_edge: f32 = 0.7;
+    left_edge: f32 = 0.31168655;
+    right_edge: f32 = 0.72704995;
+    top_edge: f32 = 0.35551643;
+    bottom_edge: f32 = 0.61583114;
 }
 
 const BACKGROUND_COLOR: (u8, u8, u8) = (32, 32, 32);

--- a/src/apps/wireframe_text.rs
+++ b/src/apps/wireframe_text.rs
@@ -1,0 +1,180 @@
+use crate::engine::{Application, EngineState};
+use crate::tuneable::write_all_to_source;
+use crate::tuneables;
+use crate::apps::text::geometric::GeometricText;
+use fontdue::{Font, FontSettings};
+
+tuneables! {
+    square_x: f32 = 0.4678812;
+    square_y: f32 = 0.6614094;
+}
+
+const BACKGROUND_COLOR: (u8, u8, u8) = (32, 32, 32);
+const TEXT_COLOR: (u8, u8, u8) = (255, 255, 255);
+const SQUARE_COLOR: (u8, u8, u8) = (64, 64, 64);
+const SQUARE_WIDTH: f32 = 400.0;
+const SQUARE_HEIGHT: f32 = 200.0;
+
+pub struct WireframeText {
+    pub text_engine: GeometricText,
+    dragging: bool,
+    drag_offset_x: f32,
+    drag_offset_y: f32,
+}
+
+impl WireframeText {
+    pub fn new() -> Self {
+        let font_bytes = include_bytes!("../../assets/JetBrainsMono-Regular.ttf") as &[u8];
+        let font = Font::from_bytes(font_bytes, FontSettings::default()).unwrap();
+        let mut text_engine = GeometricText::new(font, 24.0);
+        text_engine.set_text("start typing...".to_string());
+
+        Self {
+            text_engine,
+            dragging: false,
+            drag_offset_x: 0.0,
+            drag_offset_y: 0.0,
+        }
+    }
+
+    fn clamp_position(x: f32, y: f32, width: u32, height: u32) -> (f32, f32) {
+        let half_w = SQUARE_WIDTH / (2.0 * width as f32);
+        let half_h = SQUARE_HEIGHT / (2.0 * height as f32);
+        let cx = x.clamp(half_w, 1.0 - half_w);
+        let cy = y.clamp(half_h, 1.0 - half_h);
+        (cx, cy)
+    }
+
+    fn get_absolute_xy(state: &EngineState) -> (f32, f32) {
+        let norm_x = square_x().get();
+        let norm_y = square_y().get();
+        (
+            norm_x * state.frame.width as f32,
+            norm_y * state.frame.height as f32,
+        )
+    }
+
+    fn draw_square(&self, buffer: &mut [u8], width: u32, height: u32, x: f32, y: f32) -> (i32, i32, u32, u32) {
+        let half_w = SQUARE_WIDTH / 2.0;
+        let half_h = SQUARE_HEIGHT / 2.0;
+        let x0 = (x - half_w).max(0.0).round() as i32;
+        let y0 = (y - half_h).max(0.0).round() as i32;
+        let w = SQUARE_WIDTH.round() as u32;
+        let h = SQUARE_HEIGHT.round() as u32;
+
+        for dy in 0..h {
+            for dx in 0..w {
+                let sx = x0 + dx as i32;
+                let sy = y0 + dy as i32;
+                if sx >= 0 && sx < width as i32 && sy >= 0 && sy < height as i32 {
+                    let idx = ((sy as u32 * width + sx as u32) * 4) as usize;
+                    buffer[idx + 0] = SQUARE_COLOR.0;
+                    buffer[idx + 1] = SQUARE_COLOR.1;
+                    buffer[idx + 2] = SQUARE_COLOR.2;
+                    buffer[idx + 3] = 0xff;
+                }
+            }
+        }
+
+        (x0, y0, w, h)
+    }
+
+    fn draw_text(&mut self, state: &mut EngineState, tx: i32, ty: i32, tw: u32, th: u32) {
+        let buffer = &mut state.frame.buffer;
+        let width = state.frame.width;
+        let height = state.frame.height;
+        self.text_engine.tick(tw as f32, th as f32);
+
+        for character in &self.text_engine.characters {
+            let px = tx + character.x as i32;
+            let py = ty + character.y as i32;
+
+            for y in 0..character.metrics.height {
+                for x in 0..character.metrics.width {
+                    let val = character.bitmap[y * character.metrics.width + x];
+
+                    let sx = px + x as i32;
+                    let sy = py + y as i32;
+
+                    if sx >= 0 && sx < width as i32 && sy >= 0 && sy < height as i32 {
+                        let idx = ((sy as u32 * width + sx as u32) * 4) as usize;
+                        buffer[idx + 0] = ((TEXT_COLOR.0 as u16 * val as u16) / 255) as u8;
+                        buffer[idx + 1] = ((TEXT_COLOR.1 as u16 * val as u16) / 255) as u8;
+                        buffer[idx + 2] = ((TEXT_COLOR.2 as u16 * val as u16) / 255) as u8;
+                        buffer[idx + 3] = val;
+                    }
+                }
+            }
+        }
+    }
+
+    fn is_inside(&self, x: f32, y: f32, mx: f32, my: f32) -> bool {
+        let half_w = SQUARE_WIDTH / 2.0;
+        let half_h = SQUARE_HEIGHT / 2.0;
+        mx >= x - half_w && mx <= x + half_w && my >= y - half_h && my <= y + half_h
+    }
+}
+
+impl Application for WireframeText {
+    fn setup(&mut self, _state: &mut EngineState) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn tick(&mut self, state: &mut EngineState) {
+        state.frame.buffer.chunks_exact_mut(4).for_each(|p| {
+            p[0] = BACKGROUND_COLOR.0;
+            p[1] = BACKGROUND_COLOR.1;
+            p[2] = BACKGROUND_COLOR.2;
+            p[3] = 0xff;
+        });
+
+        let (abs_x, abs_y) = Self::get_absolute_xy(state);
+        let (x0, y0, w, h) = self.draw_square(&mut state.frame.buffer, state.frame.width, state.frame.height, abs_x, abs_y);
+        self.draw_text(state, x0, y0, w, h);
+    }
+
+    fn on_key_char(&mut self, _state: &mut EngineState, ch: char) {
+        match ch {
+            '\t' => self.text_engine.text.push_str("    "),
+            '\n' | '\r' => self.text_engine.text.push('\n'),
+            '\u{8}' => { self.text_engine.text.pop(); }
+            _ if !ch.is_control() => self.text_engine.text.push(ch),
+            _ => {}
+        }
+    }
+
+    fn on_mouse_down(&mut self, state: &mut EngineState) {
+        let (x, y) = Self::get_absolute_xy(state);
+        if self.is_inside(x, y, state.mouse.x, state.mouse.y) {
+            self.dragging = true;
+            self.drag_offset_x = state.mouse.x - x;
+            self.drag_offset_y = state.mouse.y - y;
+        }
+    }
+
+    fn on_mouse_up(&mut self, state: &mut EngineState) {
+        if self.dragging {
+            let raw_x = state.mouse.x - self.drag_offset_x;
+            let raw_y = state.mouse.y - self.drag_offset_y;
+            let norm_x = raw_x / state.frame.width as f32;
+            let norm_y = raw_y / state.frame.height as f32;
+            let (cx, cy) = Self::clamp_position(norm_x, norm_y, state.frame.width, state.frame.height);
+            square_x().set(cx);
+            square_y().set(cy);
+            write_all_to_source();
+        }
+        self.dragging = false;
+    }
+
+    fn on_mouse_move(&mut self, state: &mut EngineState) {
+        if self.dragging {
+            let raw_x = state.mouse.x - self.drag_offset_x;
+            let raw_y = state.mouse.y - self.drag_offset_y;
+            let norm_x = raw_x / state.frame.width as f32;
+            let norm_y = raw_y / state.frame.height as f32;
+            let (cx, cy) = Self::clamp_position(norm_x, norm_y, state.frame.width, state.frame.height);
+            square_x().set(cx);
+            square_y().set(cy);
+        }
+    }
+}

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -62,3 +62,14 @@ pub struct EngineState<'a> {
     pub frame: FrameState,
     pub mouse: MouseState<'a>,
 }
+
+pub trait Application {
+    fn setup(&mut self, state: &mut EngineState) -> Result<(), String>;
+    fn tick(&mut self, state: &mut EngineState);
+
+    fn on_mouse_down(&mut self, _state: &mut EngineState) {}
+    fn on_mouse_up(&mut self, _state: &mut EngineState) {}
+    fn on_mouse_move(&mut self, _state: &mut EngineState) {}
+    fn on_scroll(&mut self, _state: &mut EngineState, _delta_x: f32, _delta_y: f32) {}
+    fn on_key_char(&mut self, _state: &mut EngineState, _ch: char) {}
+}

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -17,19 +17,26 @@ pub enum CursorStyle {
     Crosshair,
 }
 
-pub struct CursorStyleSetter<'a> {
-    style: &'a mut CursorStyle,
+#[derive(Debug)]
+pub struct CursorStyleSetter {
+    current_style: CursorStyle,
 }
 
-impl<'a> CursorStyleSetter<'a> {
+impl CursorStyleSetter {
+    #[inline(always)]
+    pub fn get(&self) -> CursorStyle {
+        self.current_style
+    }
+
+    #[inline(always)]
     fn set(&mut self, val: CursorStyle) {
-        *self.style = val;
+        self.current_style = val;
     }
 }
 
 macro_rules! impl_cursor_style_setters {
     ($($variant:ident => $method:ident),* $(,)?) => {
-        impl<'a> CursorStyleSetter<'a> {
+        impl CursorStyleSetter {
             $(
                 #[inline(always)]
                 pub fn $method(&mut self) {
@@ -51,16 +58,18 @@ impl_cursor_style_setters! {
     Crosshair => crosshair,
 }
 
-pub struct MouseState<'a> {
+#[derive(Debug)]
+pub struct MouseState {
     pub x: f32,
     pub y: f32,
     pub is_down: bool,
-    pub style: CursorStyleSetter<'a>,
+    pub style: CursorStyleSetter,
 }
 
-pub struct EngineState<'a> {
+#[derive(Debug)]
+pub struct EngineState {
     pub frame: FrameState,
-    pub mouse: MouseState<'a>,
+    pub mouse: MouseState,
 }
 
 pub trait Application {

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -1,30 +1,64 @@
 #[derive(Debug, Clone)]
-pub struct EngineState {
-    pub frame: FrameState,
-    pub mouse: MouseState,
-}
-
-#[derive(Debug, Clone)]
 pub struct FrameState {
     pub width: u32,
     pub height: u32,
     pub buffer: Vec<u8>,
 }
 
-#[derive(Debug, Clone)]
-pub struct MouseState {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CursorStyle {
+    Default,
+    Text,
+    ResizeHorizontal,
+    ResizeVertical,
+    ResizeDiagonalNE,
+    ResizeDiagonalNW,
+    Hand,
+    Crosshair,
+}
+
+pub struct CursorStyleSetter<'a> {
+    style: &'a mut CursorStyle,
+}
+
+impl<'a> CursorStyleSetter<'a> {
+    fn set(&mut self, val: CursorStyle) {
+        *self.style = val;
+    }
+}
+
+macro_rules! impl_cursor_style_setters {
+    ($($variant:ident => $method:ident),* $(,)?) => {
+        impl<'a> CursorStyleSetter<'a> {
+            $(
+                #[inline(always)]
+                pub fn $method(&mut self) {
+                    self.set(CursorStyle::$variant);
+                }
+            )*
+        }
+    };
+}
+
+impl_cursor_style_setters! {
+    Default => default,
+    Text => text,
+    ResizeHorizontal => resize_horizontal,
+    ResizeVertical => resize_vertical,
+    ResizeDiagonalNE => resize_diagonal_ne,
+    ResizeDiagonalNW => resize_diagonal_nw,
+    Hand => hand,
+    Crosshair => crosshair,
+}
+
+pub struct MouseState<'a> {
     pub x: f32,
     pub y: f32,
     pub is_down: bool,
+    pub style: CursorStyleSetter<'a>,
 }
 
-pub trait Application {
-    fn setup(&mut self, state: &mut EngineState) -> Result<(), String>;
-    fn tick(&mut self, state: &mut EngineState);
-
-    fn on_mouse_down(&mut self, _state: &mut EngineState) {}
-    fn on_mouse_up(&mut self, _state: &mut EngineState) {}
-    fn on_mouse_move(&mut self, _state: &mut EngineState) {}
-    fn on_scroll(&mut self, _state: &mut EngineState, _delta_x: f32, _delta_y: f32) {}
-    fn on_key_char(&mut self, _state: &mut EngineState, _ch: char) {}
+pub struct EngineState<'a> {
+    pub frame: FrameState,
+    pub mouse: MouseState<'a>,
 }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -24,6 +24,13 @@ pub struct CursorStyleSetter {
 
 impl CursorStyleSetter {
     #[inline(always)]
+    pub fn new() -> Self {
+        Self {
+            current_style: CursorStyle::Default,
+        }
+    }
+
+    #[inline(always)]
     pub fn get(&self) -> CursorStyle {
         self.current_style
     }
@@ -33,6 +40,7 @@ impl CursorStyleSetter {
         self.current_style = val;
     }
 }
+
 
 macro_rules! impl_cursor_style_setters {
     ($($variant:ident => $method:ident),* $(,)?) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,14 @@ enum Commands {
         #[arg(long = "react-native")]
         react_native: bool,
     },
+
+    WireframeText {
+        #[arg(long)]
+        web: bool,
+
+        #[arg(long = "react-native")]
+        react_native: bool,
+    },
 }
 
 fn main() {
@@ -144,6 +152,10 @@ fn main() {
 
         Some(Commands::Wireframe { web, react_native }) => {
             run_game("wireframe", web, react_native);
+        }
+
+        Some(Commands::WireframeText { web, react_native }) => {
+            run_game("wireframe_text", web, react_native);
         }
 
         None => {


### PR DESCRIPTION
Now, from within the application development you can call methods like: `state.mouse.style.resize_horizontal()` to instantaneously change the mouse cursor's style to the styles available.

I implemented this so that if you run `xos wireframe-text` you can resize and move around the box that contains the text, while the tuneable values shift around :D