### PR TITLE
xos::manager watchdog and `xos kill` to kill all running xos processes (also term has /procs to view)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11472,6 +11472,7 @@ dependencies = [
  "image",
  "include_dir",
  "js-sys",
+ "libc",
  "metal 0.32.0",
  "nokhwa",
  "objc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11447,7 +11447,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xos"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xos"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 description = "Python, cross-platform (+ios📱) with built-in viewports, audio drivers, ai/ml/sci compute operations, graphics, text rasterization, and more- tensorized and accelerator ready. Let's see what you can build!"
 repository = "https://github.com/xlateai/xos"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,12 @@ darling = "0.21.3"
 variadics_please = "1"
 
 # -------------------------------------------------------------------
+# Unix TTY size (`ioctl` TIOCGWINSZ) for xos.terminal.* on macOS/Linux/*BSD
+# -------------------------------------------------------------------
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+# -------------------------------------------------------------------
 # Non-WASM native dependencies
 # -------------------------------------------------------------------
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/core/apps/hang.rs
+++ b/src/core/apps/hang.rs
@@ -1,0 +1,62 @@
+use crate::engine::{Application, EngineState};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+/// Stress app for testing shutdown reliability.
+///
+/// Behavior:
+/// - Spawns several hot-loop worker threads to create CPU pressure.
+/// - Keeps one mutex locked forever on a background thread.
+/// - Main tick tries to take the same lock, which blocks indefinitely.
+///
+/// This simulates a "hung" foreground app while still allowing out-of-band
+/// manager threads/process-kill behavior to be tested.
+pub struct HangApp {
+    gate: Arc<Mutex<()>>,
+    _workers: Vec<thread::JoinHandle<()>>,
+}
+
+impl HangApp {
+    pub fn new() -> Self {
+        Self {
+            gate: Arc::new(Mutex::new(())),
+            _workers: Vec::new(),
+        }
+    }
+}
+
+impl Application for HangApp {
+    fn setup(&mut self, _state: &mut EngineState) -> Result<(), String> {
+        println!("hang app: starting stress workers");
+
+        // Hold this lock forever so `tick()` blocks on first acquisition.
+        let gate_holder = Arc::clone(&self.gate);
+        self._workers.push(thread::spawn(move || {
+            let _guard = gate_holder.lock().unwrap();
+            loop {
+                thread::sleep(Duration::from_secs(1));
+            }
+        }));
+
+        // CPU pressure workers.
+        for _ in 0..4 {
+            self._workers.push(thread::spawn(move || {
+                let mut x: u64 = 0;
+                loop {
+                    x = x.wrapping_mul(1664525).wrapping_add(1013904223);
+                    if (x & 0x3fffff) == 0 {
+                        thread::yield_now();
+                    }
+                }
+            }));
+        }
+
+        Ok(())
+    }
+
+    fn tick(&mut self, _state: &mut EngineState) {
+        // Intentionally block forever after setup.
+        let _never = self.gate.lock().unwrap();
+    }
+}

--- a/src/core/apps/mod.rs
+++ b/src/core/apps/mod.rs
@@ -83,4 +83,5 @@ define_apps! {
     Overlay => overlay::OverlayApp,
     Remote => remote::RemoteApp,
     Mesh => mesh::MeshApp,
+    Hang => hang::HangApp,
 }

--- a/src/core/apps/overlay.rs
+++ b/src/core/apps/overlay.rs
@@ -146,6 +146,7 @@ mod win_lens {
 const NEON: (u8, u8, u8) = (57, 255, 20);
 const FRAME_STROKE: i32 = 3;
 /// Sample patch is this many times smaller than the overlay (higher = more zoom).
+#[cfg(target_os = "windows")]
 const ZOOM: f32 = 3.0;
 
 pub struct OverlayApp;
@@ -166,6 +167,7 @@ impl OverlayApp {
         fill_rect_buffer(buffer, fw, fh, w - t, t, w, h - t, c);
     }
 
+    #[cfg(target_os = "windows")]
     fn scale_bgra_to_rgba(
         src: &[u8],
         src_w: usize,

--- a/src/core/commands/terminal/terminal.py
+++ b/src/core/commands/terminal/terminal.py
@@ -12,7 +12,7 @@ FOOTER_HELP = [
     "  /help   show/hide this help",
     "  /nodes  list observed nodes by rank",
     "  /procs  list local xos-managed processes",
-    "  /channels list channels used in this terminal session",
+    "  /channels list channels seen on local managed procs",
     "  /channel <id> switch channel (same mode)",
     "  /lan | /local | /online switch mesh mode",
     "  /clear  clear chat log",
@@ -70,11 +70,34 @@ def _emit_nodes(log_lines: list[str], known_nodes: dict, mesh) -> None:
         pass
 
 
-def _emit_channels(log_lines: list[str], channels: list[str], current_channel: str, current_mode: str) -> None:
-    _append_log_line(log_lines, "channels (this terminal session):")
-    for ch in channels:
-        marker = "*" if ch == current_channel else " "
-        _append_log_line(log_lines, f" {marker} {ch}")
+def _emit_channels(log_lines: list[str], current_channel: str, current_mode: str) -> None:
+    _append_log_line(log_lines, "channels (local managed processes):")
+    procs = []
+    try:
+        procs = xos.manager.list_procs() or []
+    except Exception as e:
+        _append_log_line(log_lines, f"  error: {e}")
+        return
+
+    channel_counts: dict[str, int] = {}
+    channel_modes: dict[str, set[str]] = {}
+    for p in procs:
+        for ch in p.get("channels", []) or []:
+            cid = (ch.get("id", "") or "").strip()
+            if not cid:
+                continue
+            mode = (ch.get("mode", "local") or "local").upper()
+            channel_counts[cid] = channel_counts.get(cid, 0) + 1
+            channel_modes.setdefault(cid, set()).add(mode)
+
+    if not channel_counts:
+        _append_log_line(log_lines, "  (none)")
+    else:
+        for cid in sorted(channel_counts.keys()):
+            marker = "*" if cid == current_channel else " "
+            modes = ",".join(sorted(channel_modes.get(cid, {"LOCAL"})))
+            count = channel_counts[cid]
+            _append_log_line(log_lines, f" {marker} {cid}  mode={modes}  procs={count}")
     _append_log_line(log_lines, f"active: channel={current_channel!r} mode={current_mode.upper()}")
 
 
@@ -200,7 +223,6 @@ def main() -> None:
 
     logs: list[str] = []
     help_expanded = False
-    known_channels: list[str] = [current_channel]
     known_nodes: dict[int, dict[str, str]] = {}
     _remember_node(known_nodes, mesh.rank(), mesh.node_id(), machine_name)
     _append_log_line(logs, f"joined {current_channel!r} in {current_mode.upper()} as {machine_name}")
@@ -254,7 +276,7 @@ def main() -> None:
                     needs_render = True
                     handled = True
                 if text == "/channels":
-                    _emit_channels(logs, known_channels, current_channel, current_mode)
+                    _emit_channels(logs, current_channel, current_mode)
                     needs_render = True
                     handled = True
                 if text == "/clear":
@@ -270,8 +292,6 @@ def main() -> None:
                             next_mesh = xos.mesh.connect(id=next_channel, mode=current_mode)
                             mesh = next_mesh
                             current_channel = next_channel
-                            if next_channel not in known_channels:
-                                known_channels.append(next_channel)
                             known_nodes.clear()
                             _remember_node(known_nodes, mesh.rank(), mesh.node_id(), machine_name)
                             _append_log_line(logs, f"switched to channel {current_channel!r} ({current_mode.upper()})")

--- a/src/core/commands/terminal/terminal.py
+++ b/src/core/commands/terminal/terminal.py
@@ -230,6 +230,10 @@ def main() -> None:
     print("\x1b[?1049h\x1b[2J\x1b[H", end="", flush=True)
     _render(mesh, logs, machine_name, current_mode, current_channel, [FOOTER_DEFAULT])
     last_size = (int(xos.terminal.get_width()), int(xos.terminal.get_height()))
+    try:
+        last_proc_version = int(xos.manager.version())
+    except Exception:
+        last_proc_version = 0
 
     try:
         while True:
@@ -320,6 +324,13 @@ def main() -> None:
             size_now = (int(xos.terminal.get_width()), int(xos.terminal.get_height()))
             if size_now != last_size:
                 last_size = size_now
+                needs_render = True
+            try:
+                proc_version = int(xos.manager.version())
+            except Exception:
+                proc_version = last_proc_version
+            if proc_version != last_proc_version:
+                last_proc_version = proc_version
                 needs_render = True
 
             if needs_render:

--- a/src/core/commands/terminal/terminal.py
+++ b/src/core/commands/terminal/terminal.py
@@ -11,6 +11,7 @@ FOOTER_HELP = [
     "Commands:",
     "  /help   show/hide this help",
     "  /nodes  list observed nodes by rank",
+    "  /procs  list local xos-managed processes",
     "  /channels list channels used in this terminal session",
     "  /channel <id> switch channel (same mode)",
     "  /lan | /local | /online switch mesh mode",
@@ -77,6 +78,28 @@ def _emit_channels(log_lines: list[str], channels: list[str], current_channel: s
     _append_log_line(log_lines, f"active: channel={current_channel!r} mode={current_mode.upper()}")
 
 
+def _emit_procs(log_lines: list[str]) -> None:
+    _append_log_line(log_lines, "local managed processes:")
+    procs = []
+    try:
+        procs = xos.manager.list_procs() or []
+    except Exception as e:
+        _append_log_line(log_lines, f"  error: {e}")
+        return
+    if not procs:
+        _append_log_line(log_lines, "  (none)")
+        return
+    for p in procs:
+        rank = p.get("rank", "?")
+        pid = p.get("pid", "?")
+        label = p.get("label", "xos")
+        node_id = p.get("node_id", "")
+        _append_log_line(
+            log_lines,
+            f"  r{rank} pid={pid} {label} id={_short_node_id(node_id)}",
+        )
+
+
 def _idx(x: int, y: int, ch: int, width: int, height: int, channels: int) -> int:
     return ((x * height + y) * channels) + ch
 
@@ -108,9 +131,13 @@ def _render(
     rank = mesh.rank()
     node_id = mesh.node_id()
     node_label = "node" if nodes == 1 else "nodes"
+    try:
+        proc_count = int(xos.manager.num_procs())
+    except Exception:
+        proc_count = 0
 
     left = (
-        f"o {chat_id} | {mesh_mode.upper()} | {nodes} {node_label} | "
+        f"o {chat_id} | {mesh_mode.upper()} | {nodes} {node_label} | procs {proc_count} | "
         f"rank {rank} | id {_short_node_id(node_id)}"
     )
     right = machine_name
@@ -220,6 +247,10 @@ def main() -> None:
                     handled = True
                 if text == "/nodes":
                     _emit_nodes(logs, known_nodes, mesh)
+                    needs_render = True
+                    handled = True
+                if text == "/procs":
+                    _emit_procs(logs)
                     needs_render = True
                     handled = True
                 if text == "/channels":

--- a/src/core/lib.rs
+++ b/src/core/lib.rs
@@ -13,6 +13,7 @@ pub mod engine;
 pub mod video;
 pub mod apps;
 pub mod mesh;
+pub mod manager;
 pub mod ui;
 pub mod tensor;
 
@@ -180,6 +181,7 @@ pub mod py_engine {
 // --- Native startup ---
 #[cfg(not(target_arch = "wasm32"))]
 pub fn start(game: &str) -> Result<(), Box<dyn std::error::Error>> {
+    crate::manager::bootstrap("xos-app");
     if game == "mesh" {
         apps::mesh::run_mesh_app();
         return Ok(());
@@ -304,6 +306,8 @@ fn launch_expo() {
 
 // --- Main logic ---
 pub fn run_game(game: &str, web: bool, react_native: bool) {
+    #[cfg(not(target_arch = "wasm32"))]
+    crate::manager::bootstrap("xos-run");
     if web {
         println!("🌐 Launching '{game}' in web mode...");
         build_wasm(game);
@@ -421,6 +425,8 @@ struct XosAppArgs {
 
 
 pub fn run<T: engine::Application + 'static>(app: T) {
+    #[cfg(not(target_arch = "wasm32"))]
+    crate::manager::bootstrap("xos-run");
     let args = XosAppArgs::parse();
 
     let app_name = env!("CARGO_PKG_NAME");

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -14,7 +14,7 @@ use std::thread;
 use std::time::Duration;
 
 #[cfg(not(target_arch = "wasm32"))]
-const PROC_MESH_ID: &str = "_xos_procs";
+const PROC_MESH_ID: &str = "_xos_local_procs";
 #[cfg(not(target_arch = "wasm32"))]
 const PROC_HELLO_KIND: &str = "__xos_proc_hello__";
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -1,0 +1,206 @@
+#[cfg(not(target_arch = "wasm32"))]
+use crate::mesh::{MeshMode, MeshSession};
+#[cfg(not(target_arch = "wasm32"))]
+use serde_json::json;
+#[cfg(not(target_arch = "wasm32"))]
+use std::collections::HashMap;
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::{Arc, LazyLock, Mutex};
+#[cfg(not(target_arch = "wasm32"))]
+use std::thread;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Duration;
+
+#[cfg(not(target_arch = "wasm32"))]
+const PROC_MESH_ID: &str = "_xos_procs";
+#[cfg(not(target_arch = "wasm32"))]
+const PROC_HELLO_KIND: &str = "__xos_proc_hello__";
+#[cfg(not(target_arch = "wasm32"))]
+const PROC_KILL_KIND: &str = "__xos_proc_kill__";
+#[cfg(not(target_arch = "wasm32"))]
+const PROC_HELLO_INTERVAL_MS: u64 = 1200;
+#[cfg(not(target_arch = "wasm32"))]
+const PROC_STALE_MS: u64 = 5000;
+
+#[derive(Clone, Debug)]
+pub struct ProcSnapshot {
+    pub pid: u32,
+    pub label: String,
+    pub rank: u32,
+    pub node_id: String,
+    pub last_seen_ms: u64,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+static BOOTSTRAPPED: AtomicBool = AtomicBool::new(false);
+#[cfg(not(target_arch = "wasm32"))]
+static PROC_SESSION: LazyLock<Mutex<Option<Arc<MeshSession>>>> = LazyLock::new(|| Mutex::new(None));
+#[cfg(not(target_arch = "wasm32"))]
+static PROC_TABLE: LazyLock<Mutex<HashMap<u32, ProcSnapshot>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+#[cfg(not(target_arch = "wasm32"))]
+fn now_ms() -> u64 {
+    crate::mesh::nodes::now_unix_ms()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn my_pid() -> u32 {
+    std::process::id()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn self_snapshot(session: &MeshSession, label: &str) -> ProcSnapshot {
+    ProcSnapshot {
+        pid: my_pid(),
+        label: label.to_string(),
+        rank: session.rank(),
+        node_id: session.node_id.clone(),
+        last_seen_ms: now_ms(),
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn prune_locked(table: &mut HashMap<u32, ProcSnapshot>) {
+    let cutoff = now_ms().saturating_sub(PROC_STALE_MS);
+    table.retain(|_, p| p.last_seen_ms >= cutoff);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn remember_snapshot(mut snap: ProcSnapshot) {
+    snap.last_seen_ms = now_ms();
+    if let Ok(mut table) = PROC_TABLE.lock() {
+        table.insert(snap.pid, snap);
+        prune_locked(&mut table);
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn emit_hello(session: &MeshSession, label: &str) {
+    let payload = json!({
+        "pid": my_pid(),
+        "label": label,
+        "rank": session.rank(),
+        "node_id": session.node_id,
+        "ts_ms": now_ms(),
+    });
+    let _ = session.broadcast_json(PROC_HELLO_KIND, payload);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn handle_incoming(session: Arc<MeshSession>) {
+    loop {
+        if let Ok(Some(packets)) = session.inbox().receive(PROC_HELLO_KIND, false, false) {
+            for p in packets {
+                let body = p.body;
+                let pid = body.get("pid").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+                if pid == 0 {
+                    continue;
+                }
+                let label = body
+                    .get("label")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("xos")
+                    .to_string();
+                let rank = body
+                    .get("rank")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(p.from_rank as u64) as u32;
+                let node_id = body
+                    .get("node_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(p.from_id.as_str())
+                    .to_string();
+                remember_snapshot(ProcSnapshot {
+                    pid,
+                    label,
+                    rank,
+                    node_id,
+                    last_seen_ms: now_ms(),
+                });
+            }
+        }
+        if let Ok(Some(_)) = session.inbox().receive(PROC_KILL_KIND, false, true) {
+            std::process::exit(0);
+        }
+        thread::sleep(Duration::from_millis(80));
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn bootstrap(label: &str) {
+    if BOOTSTRAPPED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    println!("hello from watchdog");
+    let Ok(session) = MeshSession::join(PROC_MESH_ID, MeshMode::Local) else {
+        return;
+    };
+    let session = Arc::new(session);
+    if let Ok(mut g) = PROC_SESSION.lock() {
+        *g = Some(Arc::clone(&session));
+    }
+    remember_snapshot(self_snapshot(&session, label));
+    emit_hello(&session, label);
+
+    let reader_session = Arc::clone(&session);
+    thread::spawn(move || handle_incoming(reader_session));
+
+    let hb_session = Arc::clone(&session);
+    let label_owned = label.to_string();
+    thread::spawn(move || loop {
+        remember_snapshot(self_snapshot(&hb_session, &label_owned));
+        emit_hello(&hb_session, &label_owned);
+        thread::sleep(Duration::from_millis(PROC_HELLO_INTERVAL_MS));
+    });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn list_processes() -> Vec<ProcSnapshot> {
+    if let Ok(mut table) = PROC_TABLE.lock() {
+        prune_locked(&mut table);
+        let mut out: Vec<ProcSnapshot> = table.values().cloned().collect();
+        out.sort_by(|a, b| a.rank.cmp(&b.rank).then_with(|| a.pid.cmp(&b.pid)));
+        out
+    } else {
+        Vec::new()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn num_processes() -> usize {
+    list_processes().len()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn kill_all() -> Result<(), String> {
+    let Some(session) = PROC_SESSION
+        .lock()
+        .map_err(|_| "manager session lock poisoned".to_string())?
+        .as_ref()
+        .cloned()
+    else {
+        return Err("manager mesh is not initialized".to_string());
+    };
+    session.broadcast_json(PROC_KILL_KIND, json!({"from_pid": my_pid()}))
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn bootstrap(_label: &str) {}
+
+#[cfg(target_arch = "wasm32")]
+pub fn list_processes() -> Vec<ProcSnapshot> {
+    Vec::new()
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn num_processes() -> usize {
+    0
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn kill_all() -> Result<(), String> {
+    Err("process manager not available on wasm".to_string())
+}

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(not(target_arch = "wasm32"))]
+use std::sync::atomic::AtomicU64;
+#[cfg(not(target_arch = "wasm32"))]
 use std::sync::{Arc, LazyLock, Mutex};
 #[cfg(not(target_arch = "wasm32"))]
 use std::thread;
@@ -20,9 +22,9 @@ const PROC_HELLO_KIND: &str = "__xos_proc_hello__";
 #[cfg(not(target_arch = "wasm32"))]
 const PROC_KILL_KIND: &str = "__xos_proc_kill__";
 #[cfg(not(target_arch = "wasm32"))]
-const PROC_HELLO_INTERVAL_MS: u64 = 1200;
+const PROC_HELLO_INTERVAL_MS: u64 = 350;
 #[cfg(not(target_arch = "wasm32"))]
-const PROC_STALE_MS: u64 = 5000;
+const PROC_STALE_MS: u64 = 1200;
 
 #[derive(Clone, Debug)]
 pub struct ProcChannel {
@@ -47,6 +49,8 @@ static PROC_SESSION: LazyLock<Mutex<Option<Arc<MeshSession>>>> = LazyLock::new(|
 #[cfg(not(target_arch = "wasm32"))]
 static PROC_TABLE: LazyLock<Mutex<HashMap<u32, ProcSnapshot>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
+#[cfg(not(target_arch = "wasm32"))]
+static PROC_VERSION: AtomicU64 = AtomicU64::new(1);
 #[cfg(not(target_arch = "wasm32"))]
 static SELF_CHANNELS: LazyLock<Mutex<HashMap<String, String>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
@@ -99,8 +103,27 @@ fn prune_locked(table: &mut HashMap<u32, ProcSnapshot>) {
 fn remember_snapshot(mut snap: ProcSnapshot) {
     snap.last_seen_ms = now_ms();
     if let Ok(mut table) = PROC_TABLE.lock() {
+        let changed = match table.get(&snap.pid) {
+            Some(old) => {
+                old.label != snap.label
+                    || old.rank != snap.rank
+                    || old.node_id != snap.node_id
+                    || old.channels.len() != snap.channels.len()
+                    || old
+                        .channels
+                        .iter()
+                        .zip(snap.channels.iter())
+                        .any(|(a, b)| a.id != b.id || a.mode != b.mode)
+            }
+            None => true,
+        };
         table.insert(snap.pid, snap);
+        let before = table.len();
         prune_locked(&mut table);
+        let after = table.len();
+        if changed || before != after {
+            PROC_VERSION.fetch_add(1, Ordering::SeqCst);
+        }
     }
 }
 
@@ -208,7 +231,12 @@ pub fn bootstrap(label: &str) {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn list_processes() -> Vec<ProcSnapshot> {
     if let Ok(mut table) = PROC_TABLE.lock() {
+        let before = table.len();
         prune_locked(&mut table);
+        let after = table.len();
+        if before != after {
+            PROC_VERSION.fetch_add(1, Ordering::SeqCst);
+        }
         let mut out: Vec<ProcSnapshot> = table.values().cloned().collect();
         out.sort_by(|a, b| a.rank.cmp(&b.rank).then_with(|| a.pid.cmp(&b.pid)));
         out
@@ -220,6 +248,11 @@ pub fn list_processes() -> Vec<ProcSnapshot> {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn num_processes() -> usize {
     list_processes().len()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn snapshot_version() -> u64 {
+    PROC_VERSION.load(Ordering::SeqCst)
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -240,7 +273,14 @@ pub fn register_mesh(mesh_id: &str, mode: &str) {
     let Ok(mut chs) = SELF_CHANNELS.lock() else {
         return;
     };
-    chs.insert(mesh_id.to_string(), mode.to_string());
+    let prev = chs.insert(mesh_id.to_string(), mode.to_string());
+    let changed = match prev {
+        Some(m) => m != mode,
+        None => true,
+    };
+    if changed {
+        PROC_VERSION.fetch_add(1, Ordering::SeqCst);
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -253,6 +293,11 @@ pub fn list_processes() -> Vec<ProcSnapshot> {
 
 #[cfg(target_arch = "wasm32")]
 pub fn num_processes() -> usize {
+    0
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn snapshot_version() -> u64 {
     0
 }
 

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -25,11 +25,18 @@ const PROC_HELLO_INTERVAL_MS: u64 = 1200;
 const PROC_STALE_MS: u64 = 5000;
 
 #[derive(Clone, Debug)]
+pub struct ProcChannel {
+    pub id: String,
+    pub mode: String,
+}
+
+#[derive(Clone, Debug)]
 pub struct ProcSnapshot {
     pub pid: u32,
     pub label: String,
     pub rank: u32,
     pub node_id: String,
+    pub channels: Vec<ProcChannel>,
     pub last_seen_ms: u64,
 }
 
@@ -39,6 +46,9 @@ static BOOTSTRAPPED: AtomicBool = AtomicBool::new(false);
 static PROC_SESSION: LazyLock<Mutex<Option<Arc<MeshSession>>>> = LazyLock::new(|| Mutex::new(None));
 #[cfg(not(target_arch = "wasm32"))]
 static PROC_TABLE: LazyLock<Mutex<HashMap<u32, ProcSnapshot>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+#[cfg(not(target_arch = "wasm32"))]
+static SELF_CHANNELS: LazyLock<Mutex<HashMap<String, String>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -58,8 +68,25 @@ fn self_snapshot(session: &MeshSession, label: &str) -> ProcSnapshot {
         label: label.to_string(),
         rank: session.rank(),
         node_id: session.node_id.clone(),
+        channels: local_channels(),
         last_seen_ms: now_ms(),
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn local_channels() -> Vec<ProcChannel> {
+    let Ok(chs) = SELF_CHANNELS.lock() else {
+        return Vec::new();
+    };
+    let mut out: Vec<ProcChannel> = chs
+        .iter()
+        .map(|(id, mode)| ProcChannel {
+            id: id.clone(),
+            mode: mode.clone(),
+        })
+        .collect();
+    out.sort_by(|a, b| a.id.cmp(&b.id).then_with(|| a.mode.cmp(&b.mode)));
+    out
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -79,11 +106,13 @@ fn remember_snapshot(mut snap: ProcSnapshot) {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn emit_hello(session: &MeshSession, label: &str) {
+    let channels = local_channels();
     let payload = json!({
         "pid": my_pid(),
         "label": label,
         "rank": session.rank(),
         "node_id": session.node_id,
+        "channels": channels.iter().map(|c| json!({"id": c.id, "mode": c.mode})).collect::<Vec<_>>(),
         "ts_ms": now_ms(),
     });
     let _ = session.broadcast_json(PROC_HELLO_KIND, payload);
@@ -113,11 +142,29 @@ fn handle_incoming(session: Arc<MeshSession>) {
                     .and_then(|v| v.as_str())
                     .unwrap_or(p.from_id.as_str())
                     .to_string();
+                let mut channels: Vec<ProcChannel> = Vec::new();
+                if let Some(arr) = body.get("channels").and_then(|v| v.as_array()) {
+                    for ch in arr {
+                        let Some(id) = ch.get("id").and_then(|v| v.as_str()) else {
+                            continue;
+                        };
+                        let mode = ch
+                            .get("mode")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("local")
+                            .to_string();
+                        channels.push(ProcChannel {
+                            id: id.to_string(),
+                            mode,
+                        });
+                    }
+                }
                 remember_snapshot(ProcSnapshot {
                     pid,
                     label,
                     rank,
                     node_id,
+                    channels,
                     last_seen_ms: now_ms(),
                 });
             }
@@ -138,6 +185,7 @@ pub fn bootstrap(label: &str) {
     let Ok(session) = MeshSession::join(PROC_MESH_ID, MeshMode::Local) else {
         return;
     };
+    register_mesh(PROC_MESH_ID, "local");
     let session = Arc::new(session);
     if let Ok(mut g) = PROC_SESSION.lock() {
         *g = Some(Arc::clone(&session));
@@ -187,6 +235,14 @@ pub fn kill_all() -> Result<(), String> {
     session.broadcast_json(PROC_KILL_KIND, json!({"from_pid": my_pid()}))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+pub fn register_mesh(mesh_id: &str, mode: &str) {
+    let Ok(mut chs) = SELF_CHANNELS.lock() else {
+        return;
+    };
+    chs.insert(mesh_id.to_string(), mode.to_string());
+}
+
 #[cfg(target_arch = "wasm32")]
 pub fn bootstrap(_label: &str) {}
 
@@ -204,3 +260,6 @@ pub fn num_processes() -> usize {
 pub fn kill_all() -> Result<(), String> {
     Err("process manager not available on wasm".to_string())
 }
+
+#[cfg(target_arch = "wasm32")]
+pub fn register_mesh(_mesh_id: &str, _mode: &str) {}

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -134,7 +134,7 @@ pub fn bootstrap(label: &str) {
     if BOOTSTRAPPED.swap(true, Ordering::SeqCst) {
         return;
     }
-    println!("hello from watchdog");
+    // println!("hello from watchdog");
     let Ok(session) = MeshSession::join(PROC_MESH_ID, MeshMode::Local) else {
         return;
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,9 @@ enum Commands {
     /// Open the mesh terminal console (`xos terminal` / `xos term`).
     #[command(name = "terminal", visible_alias = "term")]
     Terminal,
+    /// Broadcast kill to all locally managed xos processes.
+    #[command(name = "kill")]
+    Kill,
 }
 
 /// ANSI orange (256-color) for `(uncommitted changes)` when stdout is a TTY.
@@ -205,6 +208,7 @@ fn main() {
                     | "path"
                     | "login"
                     | "terminal"
+                    | "kill"
                     | "-h"
                     | "--help"
                     | "-v"
@@ -234,6 +238,7 @@ fn main() {
                     | "path"
                     | "login"
                     | "terminal"
+                    | "kill"
                     | "-h"
                     | "--help"
                     | "-v"
@@ -252,6 +257,8 @@ fn main() {
     }
 
     let cli = Cli::parse_from(original_args);
+    let manager_label = exe_stem.as_deref().unwrap_or("xos");
+    xos::manager::bootstrap(manager_label);
 
     if cli.print_version {
         let bin_name = if invoked_as_xpy {
@@ -370,6 +377,13 @@ fn main() {
             };
             let script = root.join("src/core/commands/terminal/terminal.py");
             xos::apps::mesh::run_mesh_python_file(&script);
+        }
+        Some(Commands::Kill) => {
+            if let Err(e) = xos::manager::kill_all() {
+                eprintln!("❌ {e}");
+                std::process::exit(1);
+            }
+            println!("sent kill signal to local managed processes");
         }
         None => {
             eprintln!("❗ No command provided.\n");

--- a/src/py/manager.rs
+++ b/src/py/manager.rs
@@ -1,0 +1,27 @@
+use rustpython_vm::{PyRef, PyResult, VirtualMachine, builtins::PyModule, function::FuncArgs};
+
+fn manager_num_procs(_args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    Ok(vm.ctx.new_int(crate::manager::num_processes() as isize).into())
+}
+
+fn manager_list_procs(_args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    let snaps = crate::manager::list_processes();
+    let mut items = Vec::with_capacity(snaps.len());
+    for p in snaps {
+        let d = vm.ctx.new_dict();
+        d.set_item("pid", vm.ctx.new_int(p.pid as isize).into(), vm)?;
+        d.set_item("label", vm.ctx.new_str(p.label.as_str()).into(), vm)?;
+        d.set_item("rank", vm.ctx.new_int(p.rank as isize).into(), vm)?;
+        d.set_item("node_id", vm.ctx.new_str(p.node_id.as_str()).into(), vm)?;
+        d.set_item("last_seen_ms", vm.ctx.new_int(p.last_seen_ms as isize).into(), vm)?;
+        items.push(d.into());
+    }
+    Ok(vm.ctx.new_list(items).into())
+}
+
+pub fn make_manager_module(vm: &VirtualMachine) -> PyRef<PyModule> {
+    let module = vm.new_module("xos.manager", vm.ctx.new_dict(), None);
+    let _ = module.set_attr("num_procs", vm.new_function("num_procs", manager_num_procs), vm);
+    let _ = module.set_attr("list_procs", vm.new_function("list_procs", manager_list_procs), vm);
+    module
+}

--- a/src/py/manager.rs
+++ b/src/py/manager.rs
@@ -4,6 +4,10 @@ fn manager_num_procs(_args: FuncArgs, vm: &VirtualMachine) -> PyResult {
     Ok(vm.ctx.new_int(crate::manager::num_processes() as isize).into())
 }
 
+fn manager_version(_args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    Ok(vm.ctx.new_int(crate::manager::snapshot_version() as isize).into())
+}
+
 fn manager_list_procs(_args: FuncArgs, vm: &VirtualMachine) -> PyResult {
     let snaps = crate::manager::list_processes();
     let mut items = Vec::with_capacity(snaps.len());
@@ -30,6 +34,7 @@ fn manager_list_procs(_args: FuncArgs, vm: &VirtualMachine) -> PyResult {
 pub fn make_manager_module(vm: &VirtualMachine) -> PyRef<PyModule> {
     let module = vm.new_module("xos.manager", vm.ctx.new_dict(), None);
     let _ = module.set_attr("num_procs", vm.new_function("num_procs", manager_num_procs), vm);
+    let _ = module.set_attr("version", vm.new_function("version", manager_version), vm);
     let _ = module.set_attr("list_procs", vm.new_function("list_procs", manager_list_procs), vm);
     module
 }

--- a/src/py/manager.rs
+++ b/src/py/manager.rs
@@ -14,6 +14,14 @@ fn manager_list_procs(_args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         d.set_item("rank", vm.ctx.new_int(p.rank as isize).into(), vm)?;
         d.set_item("node_id", vm.ctx.new_str(p.node_id.as_str()).into(), vm)?;
         d.set_item("last_seen_ms", vm.ctx.new_int(p.last_seen_ms as isize).into(), vm)?;
+        let mut channels = Vec::with_capacity(p.channels.len());
+        for ch in p.channels {
+            let c = vm.ctx.new_dict();
+            c.set_item("id", vm.ctx.new_str(ch.id.as_str()).into(), vm)?;
+            c.set_item("mode", vm.ctx.new_str(ch.mode.as_str()).into(), vm)?;
+            channels.push(c.into());
+        }
+        d.set_item("channels", vm.ctx.new_list(channels).into(), vm)?;
         items.push(d.into());
     }
     Ok(vm.ctx.new_list(items).into())

--- a/src/py/mesh/mod.rs
+++ b/src/py/mesh/mod.rs
@@ -276,6 +276,7 @@ fn mesh_connect(args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             vm.new_runtime_error(e)
         }
     })?;
+    crate::manager::register_mesh(&mesh_id, &mode_str);
     *MESH.lock().unwrap() = Some(std::sync::Arc::new(session));
     Ok(vm.ctx.none())
 }

--- a/src/py/mod.rs
+++ b/src/py/mod.rs
@@ -19,6 +19,7 @@ pub mod burn_train;
 pub mod mesh;
 pub mod mouse;
 pub mod terminal;
+pub mod manager;
 
 use rustpython_vm::{PyRef, VirtualMachine, builtins::PyModule};
 

--- a/src/py/terminal.rs
+++ b/src/py/terminal.rs
@@ -38,7 +38,38 @@ fn platform_size() -> Option<(i32, i32)> {
     }
 }
 
-#[cfg(not(target_os = "windows"))]
+/// Real terminal dimensions from the controlling TTY (updates on resize).
+#[cfg(unix)]
+fn platform_size() -> Option<(i32, i32)> {
+    use std::mem::MaybeUninit;
+    use std::os::unix::io::AsRawFd;
+
+    fn ioctl_winsize(fd: std::os::unix::io::RawFd) -> Option<(i32, i32)> {
+        let mut ws = MaybeUninit::<libc::winsize>::uninit();
+        // SAFETY: `TIOCGWINSZ` writes a `winsize` when `fd` refers to a TTY.
+        let ret = unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, ws.as_mut_ptr()) };
+        if ret != 0 {
+            return None;
+        }
+        let ws = unsafe { ws.assume_init() };
+        let cols = ws.ws_col as i32;
+        let rows = ws.ws_row as i32;
+        if cols > 0 && rows > 0 {
+            Some((cols, rows))
+        } else {
+            None
+        }
+    }
+
+    let stdout = std::io::stdout();
+    let stderr = std::io::stderr();
+    let stdin = std::io::stdin();
+    ioctl_winsize(stdout.as_raw_fd())
+        .or_else(|| ioctl_winsize(stderr.as_raw_fd()))
+        .or_else(|| ioctl_winsize(stdin.as_raw_fd()))
+}
+
+#[cfg(all(not(unix), not(target_os = "windows")))]
 fn platform_size() -> Option<(i32, i32)> {
     None
 }

--- a/src/py/xos_module.rs
+++ b/src/py/xos_module.rs
@@ -1096,6 +1096,10 @@ pub fn make_module(vm: &VirtualMachine) -> PyRef<PyModule> {
     // Add terminal helpers for terminal-aware Python apps.
     let terminal_module = crate::python_api::terminal::make_terminal_module(vm);
     module.set_attr("terminal", terminal_module, vm).unwrap();
+
+    // Add process manager helpers.
+    let manager_module = crate::python_api::manager::make_manager_module(vm);
+    module.set_attr("manager", manager_module, vm).unwrap();
     
     // Add the dialoguer submodule
     let dialoguer_module = crate::python_api::dialoguer::make_dialoguer_module(vm);


### PR DESCRIPTION
video in discord [here](https://discord.com/channels/1294589821649551450/1348027785209184419/1492985558115549324).

1. `xos::manager` in rust creates a new local-only special case mesh called "_xos_procs" which is designed to allow us to query all available locally running xos processes no matter what, and even signal to kill them via `xos kill`.
2. should be resilient to more nasty program hangs, tested with `xos app hang` which introduces a rust-level program hang for which `xos kill` handles cleanly.
3. inside of `xos terminal` we can view the currently available running xos scripts since it will be automatically connected to the xos procs mesh, making them visible locally (even `xpy` interactive consoles) and kill them with `xos kill`.