### PR TITLE
Online Mode Mesh (`xos relay`) and release v0.3.17 finally fixed

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -39,10 +39,10 @@ jobs:
       - name: 🎯 Wasm target
         run: rustup target add wasm32-unknown-unknown
 
-      - name: 🧰 Install native deps (bindgen/libclang)
+      - name: 🧰 Install native deps (bindgen/cmake)
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends clang libclang-dev
+          apt-get install -y --no-install-recommends build-essential clang cmake libclang-dev
 
       - name: 🔨 Install bins
         run: cargo install --path . --locked --force --root /usr/local --bin xos --bin xpy --bin xrs

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -18,6 +18,7 @@ jobs:
       CARGO_TERM_COLOR: always
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_CACHE_SIZE: 2G
+      WASM_PACK_VERSION: "0.13.1"
 
     steps:
       - name: Checkout
@@ -66,17 +67,17 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/wasm-pack
-          key: wasm-pack-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          key: wasm-pack-${{ runner.os }}-${{ env.WASM_PACK_VERSION }}
           restore-keys: |
             wasm-pack-${{ runner.os }}-
 
       - name: Install wasm-pack
         if: steps.cache-wasm-pack.outputs.cache-hit != 'true'
-        run: cargo install wasm-pack
+        run: cargo install wasm-pack --version "${WASM_PACK_VERSION}" --locked
 
       - name: Ensure wasm-pack installed
         run: |
-          command -v wasm-pack >/dev/null 2>&1 || cargo install wasm-pack
+          command -v wasm-pack >/dev/null 2>&1 || cargo install wasm-pack --version "${WASM_PACK_VERSION}" --locked
 
       - name: Verify wasm-pack installation
         run: wasm-pack --version

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
         default: xlateai/xos:latest
+      artifact_name:
+        description: Artifact name to upload
+        required: false
+        type: string
+        default: xos-wasm-zip
   workflow_dispatch:
 
 jobs:
@@ -68,6 +73,6 @@ jobs:
       - name: 📤 Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: xos-wasm-zip
+          name: ${{ inputs.artifact_name || 'xos-wasm-zip' }}
           path: wasm-compiled-xos-output/xos-wasm.zip
           if-no-files-found: error

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,4 +1,4 @@
-name: wasm ci test
+name: 📦 Wasm build
 
 permissions:
   contents: read
@@ -18,7 +18,7 @@ on:
 
 jobs:
   wasm-build-test:
-    name: Build and verify wasm zip
+    name: 📦 Wasm Docker
     runs-on: ubuntu-latest
     container:
       image: ${{ inputs.docker_image || 'xlateai/xos:latest' }}
@@ -29,19 +29,19 @@ jobs:
       WASM_PACK_VERSION: "0.13.1"
 
     steps:
-      - name: Checkout
+      - name: 📥 Checkout
         uses: actions/checkout@v4
 
-      - name: Show toolchain versions
+      - name: 🦀 Show versions
         run: |
           rustc --version
           cargo --version
           wasm-pack --version
 
-      - name: Setup compiler cache (sccache)
+      - name: ⚡ Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.5
 
-      - name: Enable sccache if available
+      - name: ⚡ Enable cache
         shell: bash
         run: |
           set +e
@@ -54,7 +54,7 @@ jobs:
           fi
           set -e
 
-      - name: Cache Rust dependencies and build outputs
+      - name: 💾 Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
@@ -63,22 +63,22 @@ jobs:
           shared-key: xos-rust-global-cache
           add-job-id-key: false
 
-      - name: Ensure wasm target installed
+      - name: 🎯 Wasm target
         run: rustup target add wasm32-unknown-unknown
 
-      - name: Reset sccache stats
+      - name: 📊 Reset stats
         run: sccache --zero-stats || true
 
-      - name: Build xos release
+      - name: 🔨 Build xos
         run: cargo build --release -p xos
 
-      - name: Build wasm output zip
+      - name: 📦 Compile wasm
         run: cargo run --release --bin xos -- compile --wasm
 
-      - name: Show sccache stats
+      - name: 📊 sccache stats
         run: sccache --show-stats || true
 
-      - name: Print wasm zip size
+      - name: 📏 Zip metrics
         run: |
           zip_path="wasm-compiled-xos-output/xos-wasm.zip"
           test -s "$zip_path"
@@ -88,12 +88,12 @@ jobs:
           echo "Zip size (bytes): $bytes"
           echo "- wasm zip size: ${bytes} bytes" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Assert wasm zip exists
+      - name: ✅ Assert zip
         run: |
           test -s wasm-compiled-xos-output/xos-wasm.zip
           echo "Found wasm-compiled-xos-output/xos-wasm.zip"
 
-      - name: Upload wasm zip artifact
+      - name: 📤 Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: xos-wasm-zip

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -39,6 +39,11 @@ jobs:
       - name: 🎯 Wasm target
         run: rustup target add wasm32-unknown-unknown
 
+      - name: 🧰 Install native deps (bindgen/libclang)
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends clang libclang-dev
+
       - name: 🔨 Install bins
         run: cargo install --path . --locked --force --root /usr/local --bin xos --bin xpy --bin xrs
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -8,12 +8,20 @@ on:
   #   branches:
   #     - "**"
   workflow_call:
+    inputs:
+      docker_image:
+        description: Docker image used as build container
+        required: false
+        type: string
+        default: xlateai/xos:latest
   workflow_dispatch:
 
 jobs:
   wasm-build-test:
     name: Build and verify wasm zip
     runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.docker_image || 'xlateai/xos:latest' }}
     env:
       CARGO_TERM_COLOR: always
       SCCACHE_GHA_ENABLED: "true"
@@ -24,18 +32,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Linux build deps
+      - name: Show toolchain versions
         run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libasound2-dev zip
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-
-      - name: Ensure wasm target installed
-        run: rustup target add wasm32-unknown-unknown
+          rustc --version
+          cargo --version
+          wasm-pack --version
 
       - name: Setup compiler cache (sccache)
         uses: mozilla-actions/sccache-action@v0.0.5
@@ -62,25 +63,8 @@ jobs:
           shared-key: xos-rust-global-cache
           add-job-id-key: false
 
-      - name: Cache wasm-pack binary
-        id: cache-wasm-pack
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/bin/wasm-pack
-          key: wasm-pack-${{ runner.os }}-${{ env.WASM_PACK_VERSION }}
-          restore-keys: |
-            wasm-pack-${{ runner.os }}-
-
-      - name: Install wasm-pack
-        if: steps.cache-wasm-pack.outputs.cache-hit != 'true'
-        run: cargo install wasm-pack --version "${WASM_PACK_VERSION}" --locked
-
-      - name: Ensure wasm-pack installed
-        run: |
-          command -v wasm-pack >/dev/null 2>&1 || cargo install wasm-pack --version "${WASM_PACK_VERSION}" --locked
-
-      - name: Verify wasm-pack installation
-        run: wasm-pack --version
+      - name: Ensure wasm target installed
+        run: rustup target add wasm32-unknown-unknown
 
       - name: Reset sccache stats
         run: sccache --zero-stats || true

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -24,8 +24,6 @@ jobs:
       image: ${{ inputs.docker_image || 'xlateai/xos:latest' }}
     env:
       CARGO_TERM_COLOR: always
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_CACHE_SIZE: 2G
       WASM_PACK_VERSION: "0.13.1"
 
     steps:
@@ -38,45 +36,14 @@ jobs:
           cargo --version
           wasm-pack --version
 
-      - name: ⚡ Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.5
-
-      - name: ⚡ Enable cache
-        shell: bash
-        run: |
-          set +e
-          if sccache --start-server && sccache --show-stats >/dev/null 2>&1; then
-            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-            echo "Using sccache for this run."
-          else
-            echo "Sccache backend unavailable; falling back to plain rustc."
-            echo "SCCACHE_GHA_ENABLED=false" >> "$GITHUB_ENV"
-          fi
-          set -e
-
-      - name: 💾 Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            . -> target
-          cache-all-crates: true
-          shared-key: xos-rust-global-cache
-          add-job-id-key: false
-
       - name: 🎯 Wasm target
         run: rustup target add wasm32-unknown-unknown
-
-      - name: 📊 Reset stats
-        run: sccache --zero-stats || true
 
       - name: 🔨 Install bins
         run: cargo install --path . --locked --root /usr/local --bin xos --bin xpy --bin xrs
 
       - name: 📦 Compile wasm
         run: xos compile --wasm
-
-      - name: 📊 sccache stats
-        run: sccache --show-stats || true
 
       - name: 📏 Zip metrics
         run: |

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -40,7 +40,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       - name: 🔨 Install bins
-        run: cargo install --path . --locked --root /usr/local --bin xos --bin xpy --bin xrs
+        run: cargo install --path . --locked --force --root /usr/local --bin xos --bin xpy --bin xrs
 
       - name: 📦 Compile wasm
         run: xos compile --wasm

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -69,11 +69,11 @@ jobs:
       - name: 📊 Reset stats
         run: sccache --zero-stats || true
 
-      - name: 🔨 Build xos
-        run: cargo build --release -p xos
+      - name: 🔨 Install bins
+        run: cargo install --path . --locked --root /usr/local --bin xos --bin xpy --bin xrs
 
       - name: 📦 Compile wasm
-        run: cargo run --release --bin xos -- compile --wasm
+        run: xos compile --wasm
 
       - name: 📊 sccache stats
         run: sccache --show-stats || true

--- a/.github/workflows/xos.yml
+++ b/.github/workflows/xos.yml
@@ -16,9 +16,9 @@ on:
   workflow_dispatch:
 
 # One release pipeline at a time (extra pushes queue instead of overlapping publishes).
-concurrency:
-  group: release-${{ github.repository }}
-  cancel-in-progress: false
+# concurrency:
+#   group: release-${{ github.repository }}
+#   cancel-in-progress: false
 
 jobs:
   detect-version-bump:
@@ -34,6 +34,7 @@ jobs:
       docker_tag_exists: ${{ steps.check.outputs.docker_tag_exists }}
       wasm_artifact_exists: ${{ steps.check.outputs.wasm_artifact_exists }}
       wasm_artifact_id: ${{ steps.check.outputs.wasm_artifact_id }}
+      wasm_source: ${{ steps.check.outputs.wasm_source }}
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v4
@@ -54,9 +55,14 @@ jobs:
           docker_tag_exists=false
           wasm_artifact_exists=false
           wasm_artifact_id=""
+          wasm_source="none"
 
           if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             release_exists=true
+            if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" --json assets --jq '.assets[]? | select(.name=="xos-wasm.zip") | .name' | grep -q '^xos-wasm.zip$'; then
+              wasm_artifact_exists=true
+              wasm_source="release"
+            fi
           else
             changed=true
           fi
@@ -70,14 +76,17 @@ jobs:
             docker_tag_exists=true
           fi
 
-          wasm_artifact_name="xos-wasm-zip-v${current_version}"
-          wasm_artifact_id="$(
-            gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" --paginate \
-              --jq ".artifacts[] | select(.expired == false) | select(.name == \"${wasm_artifact_name}\") | .id" \
-              | head -n1 || true
-          )"
-          if [ -n "${wasm_artifact_id}" ]; then
-            wasm_artifact_exists=true
+          if [ "${wasm_artifact_exists}" != "true" ]; then
+            wasm_artifact_name="xos-wasm-zip-v${current_version}"
+            wasm_artifact_id="$(
+              gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" --paginate \
+                --jq ".artifacts[] | select(.expired == false) | select(.name == \"${wasm_artifact_name}\" or .name == \"xos-wasm-zip\") | .id" \
+                | head -n1 || true
+            )"
+            if [ -n "${wasm_artifact_id}" ]; then
+              wasm_artifact_exists=true
+              wasm_source="artifact"
+            fi
           fi
 
           echo "crate_name=${crate_name}" >> "$GITHUB_OUTPUT"
@@ -87,6 +96,7 @@ jobs:
           echo "docker_tag_exists=${docker_tag_exists}" >> "$GITHUB_OUTPUT"
           echo "wasm_artifact_exists=${wasm_artifact_exists}" >> "$GITHUB_OUTPUT"
           echo "wasm_artifact_id=${wasm_artifact_id}" >> "$GITHUB_OUTPUT"
+          echo "wasm_source=${wasm_source}" >> "$GITHUB_OUTPUT"
           echo "changed=${changed}" >> "$GITHUB_OUTPUT"
           echo "bumped=${bumped}" >> "$GITHUB_OUTPUT"
 
@@ -152,11 +162,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          artifact_id="${{ needs.detect-version-bump.outputs.wasm_artifact_id }}"
-          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > prior-wasm.zip
           rm -rf prior-wasm
           mkdir -p prior-wasm
-          unzip -o prior-wasm.zip -d prior-wasm
+          if [ "${{ needs.detect-version-bump.outputs.wasm_source }}" = "release" ]; then
+            tag="v${{ needs.detect-version-bump.outputs.current_version }}"
+            gh release download "${tag}" --repo "${GITHUB_REPOSITORY}" --pattern xos-wasm.zip --dir prior-wasm --clobber
+          else
+            artifact_id="${{ needs.detect-version-bump.outputs.wasm_artifact_id }}"
+            gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > prior-wasm.zip
+            unzip -o prior-wasm.zip -d prior-wasm
+          fi
           test -s prior-wasm/xos-wasm.zip
 
       - name: 📤 Re-upload for this run
@@ -171,8 +186,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detect-version-bump]
     if: needs.detect-version-bump.outputs.bumped == 'true'
-    outputs:
-      published: ${{ steps.set-output.outputs.published }}
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v4
@@ -180,28 +193,20 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
       - name: 🦀 Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: 🔍 Registry check
-        id: version-check
+      - name: 📤 cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
-          crate_name="${{ needs.detect-version-bump.outputs.crate_name }}"
-          version="${{ needs.detect-version-bump.outputs.current_version }}"
-          echo "Checking if ${crate_name}@${version} exists on crates.io..."
-          if cargo search "$crate_name" --limit 100 | grep -E "^$crate_name = \"$version\""; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
+          if cargo publish --no-verify 2>&1 | tee /tmp/cargo-publish.log; then
+            exit 0
           fi
-      - name: 📤 cargo publish
-        if: steps.version-check.outputs.exists != 'true'
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --no-verify
-      - name: ✅ Mark published
-        id: set-output
-        if: steps.version-check.outputs.exists != 'true'
-        run: echo "published=true" >> "$GITHUB_OUTPUT"
+          if grep -qi "already exists" /tmp/cargo-publish.log; then
+            echo "crate already published; continuing"
+            exit 0
+          fi
+          exit 1
 
   publish-github-release:
     name: 🚀 GH release

--- a/.github/workflows/xos.yml
+++ b/.github/workflows/xos.yml
@@ -5,9 +5,11 @@ permissions:
 
 on:
   push:
-    branches: [main]
+    branches: [main, mesh-online]
     paths:
       - "Cargo.toml"
+      - "Cargo.lock"
+      - "Dockerfile"
       - ".github/workflows/xos.yml"
       - ".github/workflows/wasm.yml"
   workflow_dispatch:
@@ -56,17 +58,56 @@ jobs:
           echo "changed=${changed}" >> "$GITHUB_OUTPUT"
           echo "bumped=${bumped}" >> "$GITHUB_OUTPUT"
 
-  wasm-build:
-    name: Build wasm package
+  publish-docker-image:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
     needs: [detect-version-bump]
     if: needs.detect-version-bump.outputs.bumped == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate Docker tags and labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: xlateai/xos
+          tags: |
+            type=raw,value=v${{ needs.detect-version-bump.outputs.current_version }}
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  wasm-build:
+    name: Build wasm package
+    needs: [detect-version-bump, publish-docker-image]
+    if: needs.detect-version-bump.outputs.bumped == 'true'
     uses: ./.github/workflows/wasm.yml
+    with:
+      docker_image: xlateai/xos:v${{ needs.detect-version-bump.outputs.current_version }}
     secrets: inherit
 
   publish-rust:
     name: Publish Rust crate
     runs-on: ubuntu-latest
-    needs: [detect-version-bump, wasm-build]
+    needs: [detect-version-bump, publish-docker-image, wasm-build]
     if: needs.detect-version-bump.outputs.bumped == 'true'
     outputs:
       published: ${{ steps.set-output.outputs.published }}
@@ -106,7 +147,7 @@ jobs:
   publish-github-release:
     name: Tag commit and publish GitHub release
     runs-on: ubuntu-latest
-    needs: [detect-version-bump, wasm-build, publish-rust]
+    needs: [detect-version-bump, publish-docker-image, wasm-build, publish-rust]
     if: needs.detect-version-bump.outputs.bumped == 'true'
     steps:
       - uses: actions/checkout@v4
@@ -171,3 +212,4 @@ jobs:
           set -euo pipefail
           tag="${{ steps.tag.outputs.tag }}"
           gh release upload "${tag}" wasm-artifact/xos-wasm.zip --clobber
+

--- a/.github/workflows/xos.yml
+++ b/.github/workflows/xos.yml
@@ -14,6 +14,11 @@ on:
       - ".github/workflows/wasm.yml"
   workflow_dispatch:
 
+# One release pipeline at a time (extra pushes queue instead of overlapping publishes).
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   detect-version-bump:
     name: 🔍 Release gate
@@ -87,6 +92,10 @@ jobs:
             type=raw,value=v${{ needs.detect-version-bump.outputs.current_version }}
             type=raw,value=latest
 
+      - name: ⬇️ Pull latest image
+        shell: bash
+        run: docker pull xlateai/xos:latest || true
+
       - name: 📤 Build push
         uses: docker/build-push-action@v6
         with:
@@ -95,8 +104,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   wasm-build:
     name: 📦 Wasm job
@@ -121,14 +128,6 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
       - name: 🦀 Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: 💾 Cargo cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            . -> target
-          cache-all-crates: true
-          shared-key: xos-rust-global-cache
-          add-job-id-key: false
       - name: 🔍 Registry check
         id: version-check
         shell: bash

--- a/.github/workflows/xos.yml
+++ b/.github/workflows/xos.yml
@@ -74,6 +74,14 @@ jobs:
       - uses: actions/checkout@v4
       - run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Rust dependencies and build outputs
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+          cache-all-crates: true
+          shared-key: xos-rust-global-cache
+          add-job-id-key: false
       - id: version-check
         shell: bash
         run: |

--- a/.github/workflows/xos.yml
+++ b/.github/workflows/xos.yml
@@ -47,7 +47,7 @@ jobs:
             changed=true
           fi
 
-          if [ "${GITHUB_REF}" = "refs/heads/main" ] && [ "${release_exists}" != "true" ]; then
+          if [ "${release_exists}" != "true" ]; then
             bumped=true
           fi
 

--- a/.github/workflows/xos.yml
+++ b/.github/workflows/xos.yml
@@ -1,4 +1,4 @@
-name: xos pipeline
+name: 🔁 xos CI
 
 permissions:
   contents: write
@@ -16,7 +16,7 @@ on:
 
 jobs:
   detect-version-bump:
-    name: Detect release need
+    name: 🔍 Release gate
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.check.outputs.changed }}
@@ -26,8 +26,10 @@ jobs:
       tag: ${{ steps.check.outputs.tag }}
       release_exists: ${{ steps.check.outputs.release_exists }}
     steps:
-      - uses: actions/checkout@v4
-      - id: check
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+      - name: 🏷️ Version check
+        id: check
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -59,23 +61,24 @@ jobs:
           echo "bumped=${bumped}" >> "$GITHUB_OUTPUT"
 
   publish-docker-image:
-    name: Build and push Docker image
+    name: 🐳 Push image
     runs-on: ubuntu-latest
     needs: [detect-version-bump]
     if: needs.detect-version-bump.outputs.bumped == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
+      - name: 🔧 Setup Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
+      - name: 🔐 Hub login
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Generate Docker tags and labels
+      - name: 🏷️ Image tags
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -84,7 +87,7 @@ jobs:
             type=raw,value=v${{ needs.detect-version-bump.outputs.current_version }}
             type=raw,value=latest
 
-      - name: Build and push Docker image
+      - name: 📤 Build push
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -96,7 +99,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   wasm-build:
-    name: Build wasm package
+    name: 📦 Wasm job
     needs: [detect-version-bump, publish-docker-image]
     if: needs.detect-version-bump.outputs.bumped == 'true'
     uses: ./.github/workflows/wasm.yml
@@ -105,17 +108,20 @@ jobs:
     secrets: inherit
 
   publish-rust:
-    name: Publish Rust crate
+    name: 📦 crates.io
     runs-on: ubuntu-latest
     needs: [detect-version-bump, publish-docker-image, wasm-build]
     if: needs.detect-version-bump.outputs.bumped == 'true'
     outputs:
       published: ${{ steps.set-output.outputs.published }}
     steps:
-      - uses: actions/checkout@v4
-      - run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Cache Rust dependencies and build outputs
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+      - name: 📚 Apt deps
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
+      - name: 🦀 Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: 💾 Cargo cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
@@ -123,7 +129,8 @@ jobs:
           cache-all-crates: true
           shared-key: xos-rust-global-cache
           add-job-id-key: false
-      - id: version-check
+      - name: 🔍 Registry check
+        id: version-check
         shell: bash
         run: |
           set -euo pipefail
@@ -135,39 +142,41 @@ jobs:
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
-      - name: Publish
+      - name: 📤 cargo publish
         if: steps.version-check.outputs.exists != 'true'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish --no-verify
-      - id: set-output
+      - name: ✅ Mark published
+        id: set-output
         if: steps.version-check.outputs.exists != 'true'
         run: echo "published=true" >> "$GITHUB_OUTPUT"
 
   publish-github-release:
-    name: Tag commit and publish GitHub release
+    name: 🚀 GH release
     runs-on: ubuntu-latest
     needs: [detect-version-bump, publish-docker-image, wasm-build, publish-rust]
     if: needs.detect-version-bump.outputs.bumped == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - name: 📥 Checkout deep
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Download wasm zip artifact
+      - name: ⬇️ Fetch wasm
         uses: actions/download-artifact@v4
         with:
           name: xos-wasm-zip
           path: wasm-artifact
 
-      - name: Assert downloaded wasm zip
+      - name: ✅ Verify zip
         shell: bash
         run: |
           set -euo pipefail
           test -s wasm-artifact/xos-wasm.zip
           ls -lh wasm-artifact/xos-wasm.zip
 
-      - name: Create and push tag
+      - name: 🏷️ Push tag
         id: tag
         shell: bash
         run: |
@@ -188,7 +197,7 @@ jobs:
             git push origin "${tag}"
           fi
 
-      - name: Create GitHub release
+      - name: 🎉 Ensure release
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -204,7 +213,7 @@ jobs:
               --generate-notes
           fi
 
-      - name: Upload wasm zip asset
+      - name: 📎 Upload asset
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash

--- a/.github/workflows/xos.yml
+++ b/.github/workflows/xos.yml
@@ -32,6 +32,8 @@ jobs:
       tag: ${{ steps.check.outputs.tag }}
       release_exists: ${{ steps.check.outputs.release_exists }}
       docker_tag_exists: ${{ steps.check.outputs.docker_tag_exists }}
+      wasm_artifact_exists: ${{ steps.check.outputs.wasm_artifact_exists }}
+      wasm_artifact_id: ${{ steps.check.outputs.wasm_artifact_id }}
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v4
@@ -50,6 +52,8 @@ jobs:
           bumped=false
           release_exists=false
           docker_tag_exists=false
+          wasm_artifact_exists=false
+          wasm_artifact_id=""
 
           if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             release_exists=true
@@ -66,11 +70,23 @@ jobs:
             docker_tag_exists=true
           fi
 
+          wasm_artifact_name="xos-wasm-zip-v${current_version}"
+          wasm_artifact_id="$(
+            gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" --paginate \
+              --jq ".artifacts[] | select(.expired == false) | select(.name == \"${wasm_artifact_name}\") | .id" \
+              | head -n1 || true
+          )"
+          if [ -n "${wasm_artifact_id}" ]; then
+            wasm_artifact_exists=true
+          fi
+
           echo "crate_name=${crate_name}" >> "$GITHUB_OUTPUT"
           echo "current_version=${current_version}" >> "$GITHUB_OUTPUT"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "release_exists=${release_exists}" >> "$GITHUB_OUTPUT"
           echo "docker_tag_exists=${docker_tag_exists}" >> "$GITHUB_OUTPUT"
+          echo "wasm_artifact_exists=${wasm_artifact_exists}" >> "$GITHUB_OUTPUT"
+          echo "wasm_artifact_id=${wasm_artifact_id}" >> "$GITHUB_OUTPUT"
           echo "changed=${changed}" >> "$GITHUB_OUTPUT"
           echo "bumped=${bumped}" >> "$GITHUB_OUTPUT"
 
@@ -116,16 +132,44 @@ jobs:
     if: |
       always() &&
       needs.detect-version-bump.outputs.bumped == 'true' &&
+      needs.detect-version-bump.outputs.wasm_artifact_exists != 'true' &&
       (needs.publish-docker-image.result == 'success' || needs.publish-docker-image.result == 'skipped')
     uses: ./.github/workflows/wasm.yml
     with:
       docker_image: xlateai/xos:v${{ needs.detect-version-bump.outputs.current_version }}
+      artifact_name: xos-wasm-zip-v${{ needs.detect-version-bump.outputs.current_version }}
     secrets: inherit
+
+  wasm-reuse:
+    name: ♻️ Reuse wasm artifact
+    runs-on: ubuntu-latest
+    needs: [detect-version-bump]
+    if: needs.detect-version-bump.outputs.bumped == 'true' && needs.detect-version-bump.outputs.wasm_artifact_exists == 'true'
+    steps:
+      - name: ⬇️ Download prior wasm artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_id="${{ needs.detect-version-bump.outputs.wasm_artifact_id }}"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > prior-wasm.zip
+          rm -rf prior-wasm
+          mkdir -p prior-wasm
+          unzip -o prior-wasm.zip -d prior-wasm
+          test -s prior-wasm/xos-wasm.zip
+
+      - name: 📤 Re-upload for this run
+        uses: actions/upload-artifact@v4
+        with:
+          name: xos-wasm-zip-v${{ needs.detect-version-bump.outputs.current_version }}
+          path: prior-wasm/xos-wasm.zip
+          if-no-files-found: error
 
   publish-rust:
     name: 📦 crates.io
     runs-on: ubuntu-latest
-    needs: [detect-version-bump, wasm-build]
+    needs: [detect-version-bump]
     if: needs.detect-version-bump.outputs.bumped == 'true'
     outputs:
       published: ${{ steps.set-output.outputs.published }}
@@ -162,8 +206,13 @@ jobs:
   publish-github-release:
     name: 🚀 GH release
     runs-on: ubuntu-latest
-    needs: [detect-version-bump, wasm-build, publish-rust]
-    if: needs.detect-version-bump.outputs.bumped == 'true'
+    needs: [detect-version-bump, wasm-build, wasm-reuse, publish-rust]
+    if: |
+      always() &&
+      needs.detect-version-bump.outputs.bumped == 'true' &&
+      (needs.publish-rust.result == 'success' || needs.publish-rust.result == 'skipped') &&
+      (needs.wasm-build.result == 'success' || needs.wasm-build.result == 'skipped') &&
+      (needs.wasm-reuse.result == 'success' || needs.wasm-reuse.result == 'skipped')
     steps:
       - name: 📥 Checkout deep
         uses: actions/checkout@v4
@@ -173,7 +222,7 @@ jobs:
       - name: ⬇️ Fetch wasm
         uses: actions/download-artifact@v4
         with:
-          name: xos-wasm-zip
+          name: xos-wasm-zip-v${{ needs.detect-version-bump.outputs.current_version }}
           path: wasm-artifact
 
       - name: ✅ Verify zip

--- a/.github/workflows/xos.yml
+++ b/.github/workflows/xos.yml
@@ -30,6 +30,7 @@ jobs:
       crate_name: ${{ steps.check.outputs.crate_name }}
       tag: ${{ steps.check.outputs.tag }}
       release_exists: ${{ steps.check.outputs.release_exists }}
+      docker_tag_exists: ${{ steps.check.outputs.docker_tag_exists }}
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v4
@@ -47,6 +48,7 @@ jobs:
           changed=false
           bumped=false
           release_exists=false
+          docker_tag_exists=false
 
           if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             release_exists=true
@@ -58,10 +60,16 @@ jobs:
             bumped=true
           fi
 
+          docker_tag="xlateai/xos:v${current_version}"
+          if docker manifest inspect "${docker_tag}" >/dev/null 2>&1; then
+            docker_tag_exists=true
+          fi
+
           echo "crate_name=${crate_name}" >> "$GITHUB_OUTPUT"
           echo "current_version=${current_version}" >> "$GITHUB_OUTPUT"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "release_exists=${release_exists}" >> "$GITHUB_OUTPUT"
+          echo "docker_tag_exists=${docker_tag_exists}" >> "$GITHUB_OUTPUT"
           echo "changed=${changed}" >> "$GITHUB_OUTPUT"
           echo "bumped=${bumped}" >> "$GITHUB_OUTPUT"
 
@@ -69,7 +77,7 @@ jobs:
     name: 🐳 Push image
     runs-on: ubuntu-latest
     needs: [detect-version-bump]
-    if: needs.detect-version-bump.outputs.bumped == 'true'
+    if: needs.detect-version-bump.outputs.bumped == 'true' && needs.detect-version-bump.outputs.docker_tag_exists != 'true'
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v4
@@ -92,10 +100,6 @@ jobs:
             type=raw,value=v${{ needs.detect-version-bump.outputs.current_version }}
             type=raw,value=latest
 
-      - name: ⬇️ Pull latest image
-        shell: bash
-        run: docker pull xlateai/xos:latest || true
-
       - name: 📤 Build push
         uses: docker/build-push-action@v6
         with:
@@ -108,7 +112,10 @@ jobs:
   wasm-build:
     name: 📦 Wasm job
     needs: [detect-version-bump, publish-docker-image]
-    if: needs.detect-version-bump.outputs.bumped == 'true'
+    if: |
+      always() &&
+      needs.detect-version-bump.outputs.bumped == 'true' &&
+      (needs.publish-docker-image.result == 'success' || needs.publish-docker-image.result == 'skipped')
     uses: ./.github/workflows/wasm.yml
     with:
       docker_image: xlateai/xos:v${{ needs.detect-version-bump.outputs.current_version }}
@@ -117,7 +124,7 @@ jobs:
   publish-rust:
     name: 📦 crates.io
     runs-on: ubuntu-latest
-    needs: [detect-version-bump, publish-docker-image, wasm-build]
+    needs: [detect-version-bump, wasm-build]
     if: needs.detect-version-bump.outputs.bumped == 'true'
     outputs:
       published: ${{ steps.set-output.outputs.published }}
@@ -154,7 +161,7 @@ jobs:
   publish-github-release:
     name: 🚀 GH release
     runs-on: ubuntu-latest
-    needs: [detect-version-bump, publish-docker-image, wasm-build, publish-rust]
+    needs: [detect-version-bump, wasm-build, publish-rust]
     if: needs.detect-version-bump.outputs.bumped == 'true'
     steps:
       - name: 📥 Checkout deep

--- a/.github/workflows/xos.yml
+++ b/.github/workflows/xos.yml
@@ -5,7 +5,8 @@ permissions:
 
 on:
   push:
-    branches: [main, mesh-online]
+    branches:
+      - "**"
     paths:
       - "Cargo.toml"
       - "Cargo.lock"
@@ -227,4 +228,3 @@ jobs:
           set -euo pipefail
           tag="${{ steps.tag.outputs.tag }}"
           gh release upload "${tag}" wasm-artifact/xos-wasm.zip --clobber
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12085,6 +12085,7 @@ dependencies = [
  "enigo",
  "fontdue",
  "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "half 2.7.1",
  "hkdf",
  "hound",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +349,45 @@ dependencies = [
  "wayland-client",
  "wayland-protocols",
  "zbus",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -592,6 +640,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +662,15 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bincode"
@@ -766,6 +829,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,7 +970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c1625261e56af29b79ec0ff20f8861f1f63737ffe96f3a3d585c1404f52da06"
 dependencies = [
  "ahash",
- "bincode",
+ "bincode 2.0.1",
  "burn-derive",
  "burn-std",
  "burn-tensor",
@@ -1326,6 +1398,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1416,18 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "ccm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae3c82e4355234767756212c570e29833699ab63e6ffd161887314cc5b43847"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
 ]
 
 [[package]]
@@ -1947,6 +2040,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1991,6 +2099,18 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-common"
@@ -2770,6 +2890,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3070,10 +3204,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "embassy-futures"
@@ -3378,6 +3547,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3533,6 +3712,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3547,6 +3741,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -3596,6 +3801,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -3757,6 +3963,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -4009,6 +4216,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -4293,7 +4511,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -4552,7 +4770,28 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "interceptor"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ab04c530fd82e414e40394cabe5f0ebfe30d119f10fe29d6e3561926af412e"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "log",
+ "portable-atomic",
+ "rand 0.8.5",
+ "rtcp",
+ "rtp",
+ "thiserror 1.0.69",
+ "tokio",
+ "waitgroup",
+ "webrtc-srtp",
+ "webrtc-util",
 ]
 
 [[package]]
@@ -5204,6 +5443,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if 1.0.4",
+ "digest",
+]
+
+[[package]]
 name = "md5"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5236,6 +5485,15 @@ checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -5591,6 +5849,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if 1.0.4",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+]
+
+[[package]]
+name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
@@ -5598,7 +5869,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cfg-if 1.0.4",
  "libc",
- "memoffset",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -6403,6 +6674,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6523,6 +6803,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6612,6 +6916,16 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -6746,6 +7060,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
@@ -6982,6 +7302,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7129,7 +7458,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7166,7 +7495,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7434,6 +7763,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "reborrow"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7593,6 +7936,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rfd"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7695,6 +8048,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rtcp"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8306430fb118b7834bbee50e744dc34826eca1da2158657a3d6cbc70e24c2096"
+dependencies = [
+ "bytes",
+ "thiserror 1.0.69",
+ "webrtc-util",
+]
+
+[[package]]
+name = "rtp"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68baca5b6cb4980678713f0d06ef3a432aa642baefcbfd0f4dd2ef9eb5ab550"
+dependencies = [
+ "bytes",
+ "memchr",
+ "portable-atomic",
+ "rand 0.8.5",
+ "serde",
+ "thiserror 1.0.69",
+ "webrtc-util",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7733,6 +8112,15 @@ dependencies = [
  "primal-check",
  "strength_reduce",
  "transpose",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -8028,7 +8416,7 @@ dependencies = [
  "log",
  "malachite-bigint",
  "memchr",
- "memoffset",
+ "memoffset 0.9.1",
  "nix 0.27.1",
  "num-complex",
  "num-integer",
@@ -8201,6 +8589,32 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit",
  "tiny-skia",
+]
+
+[[package]]
+name = "sdp"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a526161f474ae94b966ba622379d939a8fe46c930eebbadb73e339622599d5"
+dependencies = [
+ "rand 0.8.5",
+ "substring",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -8491,6 +8905,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -8640,6 +9064,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "stun"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea256fb46a13f9204e9dee9982997b2c3097db175a9fddaa8350310d03c4d5a3"
+dependencies = [
+ "base64 0.22.1",
+ "crc",
+ "lazy_static",
+ "md-5",
+ "rand 0.8.5",
+ "ring",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "url",
+ "webrtc-util",
+]
+
+[[package]]
+name = "substring"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -9058,11 +9510,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -9070,6 +9524,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "timsort"
@@ -9191,9 +9655,23 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
- "socket2",
+ "signal-hook-registry",
+ "socket2 0.6.3",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9469,6 +9947,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "turn"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0044fdae001dd8a1e247ea6289abf12f4fcea1331a2364da512f9cd680bbd8cb"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "futures",
+ "log",
+ "md-5",
+ "portable-atomic",
+ "rand 0.8.5",
+ "ring",
+ "stun",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "webrtc-util",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9522,7 +10021,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -9899,6 +10398,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8e76fae08f03f96e166d2dfda232190638c10e0383841252416f9cfe2ae60e6"
 
 [[package]]
+name = "waitgroup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1f50000a783467e6c0200f9d10642f4bc424e39efc1b770203e88b488f79292"
+dependencies = [
+ "atomic-waker",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10149,7 +10657,7 @@ dependencies = [
  "dlib",
  "libc",
  "log",
- "memoffset",
+ "memoffset 0.9.1",
  "once_cell",
  "pkg-config",
 ]
@@ -10206,6 +10714,215 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webrtc"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30367074d9f18231d28a74fab0120856b2b665da108d71a12beab7185a36f97b"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "cfg-if 1.0.4",
+ "hex",
+ "interceptor",
+ "lazy_static",
+ "log",
+ "portable-atomic",
+ "rand 0.8.5",
+ "rcgen",
+ "regex",
+ "ring",
+ "rtcp",
+ "rtp",
+ "rustls",
+ "sdp",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smol_str",
+ "stun",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "turn",
+ "url",
+ "waitgroup",
+ "webrtc-data",
+ "webrtc-dtls",
+ "webrtc-ice",
+ "webrtc-mdns",
+ "webrtc-media",
+ "webrtc-sctp",
+ "webrtc-srtp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-data"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec93b991efcd01b73c5b3503fa8adba159d069abe5785c988ebe14fcf8f05d1"
+dependencies = [
+ "bytes",
+ "log",
+ "portable-atomic",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-sctp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-dtls"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c9b89fc909f9da0499283b1112cd98f72fec28e55a54a9e352525ca65cd95c"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "async-trait",
+ "bincode 1.3.3",
+ "byteorder",
+ "cbc",
+ "ccm",
+ "der-parser",
+ "hkdf",
+ "hmac",
+ "log",
+ "p256",
+ "p384",
+ "portable-atomic",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rcgen",
+ "ring",
+ "rustls",
+ "sec1",
+ "serde",
+ "sha1",
+ "sha2",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+ "x25519-dalek",
+ "x509-parser",
+]
+
+[[package]]
+name = "webrtc-ice"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348b28b593f7709ac98d872beb58c0009523df652c78e01b950ab9c537ff17d"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "crc",
+ "log",
+ "portable-atomic",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "stun",
+ "thiserror 1.0.69",
+ "tokio",
+ "turn",
+ "url",
+ "uuid",
+ "waitgroup",
+ "webrtc-mdns",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-mdns"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6dfe9686c6c9c51428da4de415cb6ca2dc0591ce2b63212e23fd9cccf0e316b"
+dependencies = [
+ "log",
+ "socket2 0.5.10",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-media"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e153be16b8650021ad3e9e49ab6e5fa9fb7f6d1c23c213fd8bbd1a1135a4c704"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "rand 0.8.5",
+ "rtp",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "webrtc-sctp"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5faf3846ec4b7e64b56338d62cbafe084aa79806b0379dff5cc74a8b7a2b3063"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "crc",
+ "log",
+ "portable-atomic",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-srtp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771db9993712a8fb3886d5be4613ebf27250ef422bd4071988bf55f1ed1a64fa"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "byteorder",
+ "bytes",
+ "ctr",
+ "hmac",
+ "log",
+ "rtcp",
+ "rtp",
+ "sha1",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-util"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1438a8fd0d69c5775afb4a71470af92242dbd04059c61895163aa3c1ef933375"
+dependencies = [
+ "async-trait",
+ "bitflags 1.3.2",
+ "bytes",
+ "ipnet",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "portable-atomic",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "winapi",
 ]
 
 [[package]]
@@ -11239,6 +11956,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11384,6 +12119,7 @@ dependencies = [
  "symphonia",
  "tiny_http",
  "tokenizers",
+ "tokio",
  "ureq 2.12.1",
  "uuid",
  "variadics_please",
@@ -11391,6 +12127,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webbrowser",
+ "webrtc",
  "winapi",
  "winit",
  "x25519-dalek",
@@ -11417,6 +12154,15 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12106,6 +12106,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rand_pcg",
  "rayon",
+ "reqwest",
  "rfd",
  "ringbuf",
  "rsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ default-run = "xos"
 
 [dependencies]
 burn         = { version = "=0.21.0-pre.3", default-features = false, features = ["std", "wgpu", "autotune", "ndarray", "autodiff"] }
-burn-store   = { version = "=0.21.0-pre.3", features = ["burnpack", "pytorch"] }
 burn-cubecl  = { version = "=0.21.0-pre.3" }
 burn-fusion  = { version = "=0.21.0-pre.3" }
 burn-ir      = { version = "=0.21.0-pre.3" }
@@ -50,6 +49,7 @@ libc = "0.2"
 # Non-WASM native dependencies
 # -------------------------------------------------------------------
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+burn-store   = { version = "=0.21.0-pre.3", features = ["burnpack", "pytorch"] }
 rand = "0.9.2"
 rand_chacha = "0.3"
 rand_core = "0.6"
@@ -129,6 +129,8 @@ screencapturekit = { version = "1.5.4", features = ["macos_13_0"] }
 # -------------------------------------------------------------------
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.3.4", features = ["wasm_js"] }
+# Force-enable wasm support for transitive getrandom 0.4 users (Burn/CubeCL stack).
+getrandom_04 = { package = "getrandom", version = "0.4.2", features = ["wasm_js"] }
 uuid = { version = "1", features = ["v4", "js"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
@@ -162,7 +164,7 @@ web-sys = { version = "0.3", features = [
 console_error_panic_hook = "0.1"
 
 [features]
-default = ["whisper", "whisper_burn", "whisper_ct2"]
+default = ["whisper", "whisper_ct2"]
 ## Shared stack for live CT2 + resampling + (optional) Silero — **no** `tokenizers` / sentencepiece (avoids iOS `sentencepiece-sys`/cmake issues).
 ## Burn/WGPU is gated behind `whisper_burn` (pulls `tokenizers` for BPE only on desktop).
 whisper = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ rand = "0.9.2"
 rand_chacha = "0.3"
 rand_core = "0.6"
 getrandom = "0.3.4"
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
+webrtc = "0.12"
 # Offline identity + LAN mesh crypto (RSA handshake, AES-GCM wire)
 rsa = { version = "0.9", features = ["pem", "sha2"] }
 argon2 = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ rand_core = "0.6"
 getrandom = "0.3.4"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 webrtc = "0.12"
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 # Offline identity + LAN mesh crypto (RSA handshake, AES-GCM wire)
 rsa = { version = "0.9", features = ["pem", "sha2"] }
 argon2 = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ web-sys = { version = "0.3", features = [
 console_error_panic_hook = "0.1"
 
 [features]
-default = ["whisper", "whisper_burn", "whisper_ct2", "silero_vad"]
+default = ["whisper", "whisper_burn", "whisper_ct2"]
 ## Shared stack for live CT2 + resampling + (optional) Silero — **no** `tokenizers` / sentencepiece (avoids iOS `sentencepiece-sys`/cmake issues).
 ## Burn/WGPU is gated behind `whisper_burn` (pulls `tokenizers` for BPE only on desktop).
 whisper = [

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=planner /app/recipe.json recipe.json
+# Path crates from [patch]: must exist before chef cook (chef stage has no full tree yet)
+COPY src/core/patches/ct2rs src/core/patches/ct2rs
+COPY src/core/patches/gpu-allocator src/core/patches/gpu-allocator
+COPY src/core/patches/sentencepiece-sys src/core/patches/sentencepiece-sys
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release --locked --bin xos --bin xpy --bin xrs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM rust:1.88-bookworm AS chef
+# Needs >= rustc 1.92 (Burn/CubeCL `cubek-*`); align with repo dev toolchain (~1.94)
+FROM rust:1.94-bookworm AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /app
 
@@ -21,7 +22,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release --locked --bin xos --bin xpy --bin xrs
 
-FROM rust:1.88-bookworm AS runtime
+FROM rust:1.94-bookworm AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     pkg-config \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,12 @@ RUN cargo install --path . --locked --root /usr/local --bin xos --bin xpy --bin 
 
 FROM rust:1.94-bookworm AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
     ca-certificates \
+    clang \
+    cmake \
     git \
+    libclang-dev \
     pkg-config \
     libasound2-dev \
     libasound2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,10 @@ COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
+# bindgen (`v4l2-sys-mit`, etc.) needs libclang at compile time
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    clang \
+    libclang-dev \
     pkg-config \
     libasound2-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY src/core/patches/gpu-allocator src/core/patches/gpu-allocator
 COPY src/core/patches/sentencepiece-sys src/core/patches/sentencepiece-sys
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
-RUN cargo build --release --locked --bin xos --bin xpy --bin xrs
+RUN cargo install --path . --locked --root /usr/local --bin xos --bin xpy --bin xrs
 
 FROM rust:1.94-bookworm AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -40,7 +40,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN rustup target add wasm32-unknown-unknown
 RUN cargo install wasm-pack --version 0.13.1 --locked
 WORKDIR /app
-COPY --from=builder /app/target/release/xos /usr/local/bin/xos
-COPY --from=builder /app/target/release/xpy /usr/local/bin/xpy
-COPY --from=builder /app/target/release/xrs /usr/local/bin/xrs
+COPY --from=builder /usr/local/bin/xos /usr/local/bin/xos
+COPY --from=builder /usr/local/bin/xpy /usr/local/bin/xpy
+COPY --from=builder /usr/local/bin/xrs /usr/local/bin/xrs
 ENTRYPOINT ["xos"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM rust:1.88-bookworm AS chef
+RUN cargo install cargo-chef --locked
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config \
+    libasound2-dev \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release --locked --bin xos --bin xpy --bin xrs
+
+FROM rust:1.88-bookworm AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    pkg-config \
+    libasound2-dev \
+    libasound2 \
+    zip \
+    && rm -rf /var/lib/apt/lists/*
+RUN rustup target add wasm32-unknown-unknown
+RUN cargo install wasm-pack --version 0.13.1 --locked
+WORKDIR /app
+COPY --from=builder /app/target/release/xos /usr/local/bin/xos
+COPY --from=builder /app/target/release/xpy /usr/local/bin/xpy
+COPY --from=builder /app/target/release/xrs /usr/local/bin/xrs
+ENTRYPOINT ["xos"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,12 @@ COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
-# bindgen (`v4l2-sys-mit`, etc.) needs libclang at compile time
+# bindgen (`v4l2-sys-mit`, etc.), `sentencepiece-sys` CMake build
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
     clang \
+    git \
     libclang-dev \
     pkg-config \
     libasound2-dev \
@@ -28,6 +31,7 @@ RUN cargo build --release --locked --bin xos --bin xpy --bin xrs
 FROM rust:1.94-bookworm AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    git \
     pkg-config \
     libasound2-dev \
     libasound2 \

--- a/src/core/ai/transcription/mod.rs
+++ b/src/core/ai/transcription/mod.rs
@@ -74,6 +74,14 @@ fn spawn_live_decode_thread(
             {
                 return burn::whisper::spawn_decode_thread(preferred_size, language);
             }
+            #[cfg(all(not(feature = "whisper_burn"), not(target_os = "ios")))]
+            {
+                let _ = (preferred_size, language);
+                Err(
+                    "Whisper Burn backend is unavailable in this build (enable whisper_burn)."
+                        .to_string(),
+                )
+            }
             #[cfg(target_os = "ios")]
             {
                 let _ = (preferred_size, language);

--- a/src/core/apps/text_mesh.rs
+++ b/src/core/apps/text_mesh.rs
@@ -215,6 +215,7 @@ impl TextMeshApp {
         let mode = match self.mode {
             MeshMode::Local => "LOCAL",
             MeshMode::Lan => "LAN",
+            MeshMode::Online => "ONLINE",
         };
         let left = format!(
             "● {} | mode {} | clients {} | rev {}",

--- a/src/core/apps/text_mesh.rs
+++ b/src/core/apps/text_mesh.rs
@@ -1,7 +1,12 @@
 use crate::apps::text::text::TextApp;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::auth::{
     is_logged_in, load_identity, load_node_identity, login_offline, reset_offline_identity,
 };
+#[cfg(target_arch = "wasm32")]
+fn is_logged_in() -> bool {
+    true
+}
 use crate::engine::{Application, EngineState};
 use crate::mesh::{MeshMode, MeshSession};
 use crate::rasterizer::fill_rect_buffer;
@@ -97,7 +102,14 @@ impl TextMeshApp {
     }
 
     fn current_username() -> Option<String> {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
         load_identity().ok().map(|u| u.username).filter(|u| !u.trim().is_empty())
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            Some("web".to_string())
+        }
     }
 
     fn draw_text_line(
@@ -149,6 +161,13 @@ impl TextMeshApp {
     }
 
     fn ensure_login_identity(&self) -> Result<(), String> {
+        #[cfg(target_arch = "wasm32")]
+        {
+            let _ = self;
+            return Ok(());
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
         let user = self.username.trim();
         let pass = self.password.trim();
         if !is_logged_in() {
@@ -167,18 +186,24 @@ impl TextMeshApp {
         }
         reset_offline_identity(user, pass, user).map_err(|e| format!("login reset failed: {e}"))?;
         Ok(())
+        }
     }
 
     fn connect_mesh(&mut self) -> Result<(), String> {
         self.ensure_login_identity()?;
         self.status_user_label = Self::current_username().unwrap_or_else(|| "not logged in".to_string());
+        #[cfg(not(target_arch = "wasm32"))]
+        let session = {
         let node_identity = load_node_identity().map_err(|e| format!("node identity unavailable: {e}"))?;
-        let session = MeshSession::join_with_identity(
+        MeshSession::join_with_identity(
             self.channel.trim(),
             self.mode,
             Arc::new(node_identity),
             None,
-        )?;
+        )?
+        };
+        #[cfg(target_arch = "wasm32")]
+        let session = MeshSession::join(self.channel.trim(), self.mode)?;
         self.mesh_session = Some(Arc::new(session));
         self.phase = AppPhase::Editor;
         self.last_sent_text = self.text_app.text_rasterizer.text.clone();

--- a/src/core/apps/text_mesh.rs
+++ b/src/core/apps/text_mesh.rs
@@ -16,7 +16,8 @@ const INPUT_LEFT_PAD: f32 = 14.0;
 const LOGIN_TOP_GAP: f32 = 22.0;
 const LOGIN_LINE_GAP: f32 = 14.0;
 const DEFAULT_CHANNEL: &str = "shared-text-demo";
-const DEFAULT_MODE: MeshMode = MeshMode::Lan;
+// const DEFAULT_MODE: MeshMode = MeshMode::Lan;
+const DEFAULT_MODE: MeshMode = MeshMode::Online;
 const DOC_KIND: &str = "shared_doc_v1";
 const HOST_ANTI_ENTROPY_INTERVAL: Duration = Duration::from_millis(1800);
 

--- a/src/core/mesh/relay.rs
+++ b/src/core/mesh/relay.rs
@@ -23,8 +23,6 @@ use super::lan_crypto::{
 use crate::auth::{is_logged_in, load_identity, node_id_from_public_pem, UnlockedNodeIdentity};
 #[cfg(not(target_arch = "wasm32"))]
 use sha2::{Digest, Sha256};
-#[cfg(not(target_arch = "wasm32"))]
-use uuid::Uuid;
 
 const WIRE_VERSION: u32 = 2;
 
@@ -1272,7 +1270,6 @@ impl MeshSession {
         max_total_nodes: Option<u32>,
     ) -> Result<Self, String> {
         require_authorized_non_local_mesh(mode)?;
-        let port = port_for_mesh_id(mesh_id);
         let account_aid = {
             let auth = load_identity().map_err(|e| e.to_string())?;
             node_id_from_public_pem(auth.public_pem.as_str()).map_err(|e| e.to_string())?
@@ -1368,7 +1365,7 @@ impl MeshSession {
             from_id: self.node_id.clone(),
             kind: kind.to_string(),
             to,
-            payload,
+            payload: payload.clone(),
         };
 
         match &self.role {

--- a/src/core/mesh/relay.rs
+++ b/src/core/mesh/relay.rs
@@ -21,6 +21,8 @@ use super::lan_crypto::{
 };
 #[cfg(not(target_arch = "wasm32"))]
 use crate::auth::{is_logged_in, load_identity, node_id_from_public_pem, UnlockedNodeIdentity};
+#[cfg(not(target_arch = "wasm32"))]
+use sha2::{Digest, Sha256};
 
 const WIRE_VERSION: u32 = 2;
 
@@ -183,6 +185,8 @@ pub enum MeshMode {
     Local,
     /// Coordinator binds `0.0.0.0` on TCP; LAN peers locate it via UDP broadcast on a derived port.
     Lan,
+    /// Online/global transport. Phase 1 currently reuses encrypted LAN handshake + TCP mesh path.
+    Online,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -204,6 +208,16 @@ fn should_deliver_locally(my_rank: u32, from: u32, to: Option<u32>) -> bool {
         Some(t) => t == my_rank && from != my_rank,
         None => from != my_rank,
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn online_lookup_key(account_aid: &str, channel_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(account_aid.as_bytes());
+    hasher.update(b":");
+    hasher.update(channel_id.as_bytes());
+    let digest = hasher.finalize();
+    digest.iter().map(|b| format!("{:02x}", b)).collect()
 }
 
 /// Rank 0 + one live TCP per connected peer. Call when a peer disconnects so sends skip stale sockets.
@@ -1044,6 +1058,10 @@ impl MeshSession {
                         )),
                     }
                 }
+                MeshMode::Online => Err(
+                    "online mesh requires identity-backed join; use MeshSession::join_with_identity(..., MeshMode::Online, ...)."
+                        .to_string(),
+                ),
             }
         }
         #[cfg(not(target_arch = "wasm32"))]
@@ -1060,6 +1078,10 @@ impl MeshSession {
                 }
                 MeshMode::Lan => Err(
                     "LAN mesh requires a local login identity. Run `xos login` first."
+                        .into(),
+                ),
+                MeshMode::Online => Err(
+                    "Online mesh requires a local login identity. Run `xos login` first."
                         .into(),
                 ),
             }
@@ -1081,24 +1103,34 @@ impl MeshSession {
         };
         match mode {
             MeshMode::Local => MeshSession::join(mesh_id, MeshMode::Local),
-            MeshMode::Lan => {
+            MeshMode::Lan | MeshMode::Online => {
                 check_join_interrupt()?;
+                let scoped_mesh_id = if mode == MeshMode::Online {
+                    online_lookup_key(account_aid.as_str(), mesh_id)
+                } else {
+                    mesh_id.to_string()
+                };
+                let scoped_port = port_for_mesh_id(scoped_mesh_id.as_str());
                 // 1) Loopback first — fast when the coordinator is on this machine (discovery-first was
                 //    ~1s slower because UDP had to time out before every local join / first host bind).
                 // 2) UDP discovery for remote peers (e.g. Mac on the LAN).
                 // 3) Otherwise bind 0.0.0.0 and become coordinator.
-                let loopback = SocketAddr::from(([127, 0, 0, 1], port));
+                let loopback = SocketAddr::from(([127, 0, 0, 1], scoped_port));
                 if let Ok(s) = try_mesh_client_once(loopback, Some(Arc::clone(&identity))) {
                     return Ok(s);
                 }
-                if let Some(remote) = lan_discover_coordinator(mesh_id, port, Some(account_aid.as_str()))? {
+                if let Some(remote) = lan_discover_coordinator(
+                    scoped_mesh_id.as_str(),
+                    scoped_port,
+                    Some(account_aid.as_str()),
+                )? {
                     return mesh_session_from_client_addr(remote, Some(Arc::clone(&identity)));
                 }
-                let any = SocketAddr::from(([0, 0, 0, 0], port));
+                let any = SocketAddr::from(([0, 0, 0, 0], scoped_port));
                 match TcpListener::bind(any) {
                     Ok(listener) => mesh_session_from_host_listener(
                         listener,
-                        Some(mesh_id),
+                        Some(scoped_mesh_id.as_str()),
                         Some(identity),
                         max_total_nodes,
                     ),
@@ -1106,8 +1138,11 @@ impl MeshSession {
                         thread::sleep(Duration::from_millis(80));
                         if let Ok(s) = try_mesh_client_once(loopback, Some(Arc::clone(&identity))) {
                             Ok(s)
-                        } else if let Some(remote) =
-                            lan_discover_coordinator(mesh_id, port, Some(account_aid.as_str()))?
+                        } else if let Some(remote) = lan_discover_coordinator(
+                            scoped_mesh_id.as_str(),
+                            scoped_port,
+                            Some(account_aid.as_str()),
+                        )?
                         {
                             mesh_session_from_client_addr(remote, Some(Arc::clone(&identity)))
                         } else {
@@ -1115,10 +1150,11 @@ impl MeshSession {
                         }
                     }
                     Err(e) => Err(format!(
-                        "lan mesh: could not bind 0.0.0.0:{port} (is another app using it?): {e}"
+                        "mesh (lan/online): could not bind 0.0.0.0:{scoped_port} (is another app using it?): {e}"
                     )),
                 }
             }
+                MeshMode::Online => Err("online mesh is not available on wasm targets.".to_string()),
         }
     }
 

--- a/src/core/mesh/relay.rs
+++ b/src/core/mesh/relay.rs
@@ -23,6 +23,8 @@ use super::lan_crypto::{
 use crate::auth::{is_logged_in, load_identity, node_id_from_public_pem, UnlockedNodeIdentity};
 #[cfg(not(target_arch = "wasm32"))]
 use sha2::{Digest, Sha256};
+#[cfg(not(target_arch = "wasm32"))]
+use uuid::Uuid;
 
 const WIRE_VERSION: u32 = 2;
 
@@ -41,6 +43,10 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(20);
 
 /// TCP read timeout per mesh leg. Must stay **greater** than [`HEARTBEAT_INTERVAL`] so idle links stay up.
 const MESH_READ_TIMEOUT: Duration = Duration::from_secs(120);
+#[cfg(not(target_arch = "wasm32"))]
+const RELAY_ENV: &str = "XOS_RELAY_LINK";
+#[cfg(not(target_arch = "wasm32"))]
+const RELAY_DEFAULT: &str = "https://xos.xlate.ai";
 
 fn heartbeat_envelope(rank: u32, node_id: &str) -> WireEnvelope {
     WireEnvelope {
@@ -176,6 +182,14 @@ struct WireEnvelope {
     #[serde(skip_serializing_if = "Option::is_none")]
     to: Option<u32>,
     payload: serde_json::Value,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone)]
+struct OnlineRelayClient {
+    base: String,
+    session_id: String,
+    http: reqwest::blocking::Client,
 }
 
 /// Transport scope for [`MeshSession::join`].
@@ -562,6 +576,10 @@ enum MeshRole {
     Client {
         stream: Arc<Mutex<TcpStream>>,
     },
+    #[cfg(not(target_arch = "wasm32"))]
+    OnlineClient {
+        relay: OnlineRelayClient,
+    },
 }
 
 fn attach_mesh_heartbeat(session: &MeshSession) {
@@ -634,7 +652,41 @@ fn attach_mesh_heartbeat(session: &MeshSession) {
                 });
             }
         }
+        #[cfg(not(target_arch = "wasm32"))]
+        MeshRole::OnlineClient { .. } => {}
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn relay_base_url() -> String {
+    let raw = std::env::var(RELAY_ENV).unwrap_or_else(|_| RELAY_DEFAULT.to_string());
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        RELAY_DEFAULT.to_string()
+    } else if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        trimmed.to_string()
+    } else {
+        format!("https://{trimmed}")
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn relay_post_json(
+    http: &reqwest::blocking::Client,
+    base: &str,
+    path: &str,
+    body: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let url = format!("{}/{}", base.trim_end_matches('/'), path.trim_start_matches('/'));
+    let res = http
+        .post(url)
+        .json(body)
+        .send()
+        .map_err(|e| e.to_string())?;
+    if !res.status().is_success() {
+        return Err(format!("relay http {}", res.status()));
+    }
+    res.json::<serde_json::Value>().map_err(|e| e.to_string())
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -994,6 +1046,130 @@ fn mesh_session_from_client_addr(
     })
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+fn mesh_session_from_online_relay(
+    mesh_id: &str,
+    identity: Arc<UnlockedNodeIdentity>,
+    account_aid: &str,
+) -> Result<MeshSession, String> {
+    let relay_base = relay_base_url();
+    let http = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|e| e.to_string())?;
+    let mesh_hash_key = online_lookup_key(account_aid, mesh_id);
+    let node_hash_key = identity.node_id();
+    let connect = relay_post_json(
+        &http,
+        &relay_base,
+        "/mesh/connect",
+        &json!({
+            "mesh_hash_key": mesh_hash_key,
+            "node_hash_key": node_hash_key,
+            "node_name": identity.node_name,
+        }),
+    )?;
+    let session_id = connect
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "relay connect missing session_id".to_string())?
+        .to_string();
+    let rank = connect
+        .get("rank")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    let num_nodes = connect
+        .get("num_nodes")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(1) as u32;
+
+    let inbox = Arc::new(Inbox::new());
+    let num_nodes_a = Arc::new(AtomicU32::new(num_nodes.max(1)));
+    let connected = Arc::new(AtomicU32::new(1));
+    let shutdown = Arc::new(AtomicU32::new(0));
+    let rank_a = Arc::new(AtomicU32::new(rank));
+    let relay = OnlineRelayClient {
+        base: relay_base,
+        session_id,
+        http: http.clone(),
+    };
+
+    let session = MeshSession {
+        rank_atomic: Arc::clone(&rank_a),
+        node_id: node_hash_key,
+        node_name: identity.node_name.clone(),
+        num_nodes: Arc::clone(&num_nodes_a),
+        connected: Arc::clone(&connected),
+        inbox: Arc::clone(&inbox),
+        role: MeshRole::OnlineClient {
+            relay: relay.clone(),
+        },
+        shutdown: Arc::clone(&shutdown),
+        lan_host: None,
+        lan_client: None,
+    };
+
+    let inbox_r = Arc::clone(&inbox);
+    thread::spawn(move || {
+        loop {
+            if shutdown.load(Ordering::SeqCst) != 0 {
+                break;
+            }
+            let polled = relay_post_json(
+                &http,
+                &relay.base,
+                "/mesh/poll",
+                &json!({"session_id": relay.session_id}),
+            );
+            match polled {
+                Ok(v) => {
+                    if let Some(r) = v.get("rank").and_then(|x| x.as_u64()) {
+                        rank_a.store(r as u32, Ordering::SeqCst);
+                    }
+                    if let Some(n) = v.get("num_nodes").and_then(|x| x.as_u64()) {
+                        num_nodes_a.store((n as u32).max(1), Ordering::SeqCst);
+                    }
+                    if let Some(msgs) = v.get("messages").and_then(|x| x.as_array()) {
+                        for m in msgs {
+                            let kind = m
+                                .get("kind")
+                                .and_then(|x| x.as_str())
+                                .unwrap_or("")
+                                .to_string();
+                            if kind.is_empty()
+                                || kind == MESH_HEARTBEAT_KIND
+                                || kind == MESH_TOPOLOGY_KIND
+                            {
+                                continue;
+                            }
+                            inbox_r.push(Packet {
+                                from_rank: m
+                                    .get("from_rank")
+                                    .and_then(|x| x.as_u64())
+                                    .unwrap_or(0)
+                                    as u32,
+                                from_id: m
+                                    .get("from_id")
+                                    .and_then(|x| x.as_str())
+                                    .unwrap_or("")
+                                    .to_string(),
+                                kind,
+                                body: m.get("payload").cloned().unwrap_or_else(|| json!({})),
+                            });
+                        }
+                    }
+                }
+                Err(_) => {
+                    connected.store(0, Ordering::SeqCst);
+                }
+            }
+            thread::sleep(Duration::from_millis(120));
+        }
+    });
+
+    Ok(session)
+}
+
 impl MeshSession {
     #[inline]
     pub fn rank(&self) -> u32 {
@@ -1103,13 +1279,10 @@ impl MeshSession {
         };
         match mode {
             MeshMode::Local => MeshSession::join(mesh_id, MeshMode::Local),
-            MeshMode::Lan | MeshMode::Online => {
+            MeshMode::Online => mesh_session_from_online_relay(mesh_id, identity, account_aid.as_str()),
+            MeshMode::Lan => {
                 check_join_interrupt()?;
-                let scoped_mesh_id = if mode == MeshMode::Online {
-                    online_lookup_key(account_aid.as_str(), mesh_id)
-                } else {
-                    mesh_id.to_string()
-                };
+                let scoped_mesh_id = mesh_id.to_string();
                 let scoped_port = port_for_mesh_id(scoped_mesh_id.as_str());
                 // 1) Loopback first — fast when the coordinator is on this machine (discovery-first was
                 //    ~1s slower because UDP had to time out before every local join / first host bind).
@@ -1154,7 +1327,6 @@ impl MeshSession {
                     )),
                 }
             }
-                MeshMode::Online => Err("online mesh is not available on wasm targets.".to_string()),
         }
     }
 
@@ -1307,6 +1479,18 @@ impl MeshSession {
                     e.to_string()
                 })
             }
+            #[cfg(not(target_arch = "wasm32"))]
+            MeshRole::OnlineClient { relay } => {
+                let body = json!({
+                    "session_id": relay.session_id,
+                    "to_rank": to,
+                    "kind": kind,
+                    "payload": payload,
+                    "from_rank": self.rank_atomic.load(Ordering::SeqCst),
+                    "from_id": self.node_id,
+                });
+                relay_post_json(&relay.http, &relay.base, "/mesh/send", &body).map(|_| ())
+            }
         }
     }
 }
@@ -1314,6 +1498,15 @@ impl MeshSession {
 impl Drop for MeshSession {
     fn drop(&mut self) {
         self.shutdown.fetch_add(1, Ordering::SeqCst);
+        #[cfg(not(target_arch = "wasm32"))]
+        if let MeshRole::OnlineClient { relay } = &self.role {
+            let _ = relay_post_json(
+                &relay.http,
+                &relay.base,
+                "/mesh/disconnect",
+                &json!({"session_id": relay.session_id}),
+            );
+        }
     }
 }
 

--- a/src/core/mesh/relay.rs
+++ b/src/core/mesh/relay.rs
@@ -44,7 +44,7 @@ const MESH_READ_TIMEOUT: Duration = Duration::from_secs(120);
 #[cfg(not(target_arch = "wasm32"))]
 const RELAY_ENV: &str = "XOS_RELAY_LINK";
 #[cfg(not(target_arch = "wasm32"))]
-const RELAY_DEFAULT: &str = "https://xos.xlate.ai";
+const RELAY_DEFAULT: &str = "http://xos.xlate.ai:47333";
 
 fn heartbeat_envelope(rank: u32, node_id: &str) -> WireEnvelope {
     WireEnvelope {

--- a/src/core/mesh/relay.rs
+++ b/src/core/mesh/relay.rs
@@ -684,7 +684,15 @@ fn relay_post_json(
     if !res.status().is_success() {
         return Err(format!("relay http {}", res.status()));
     }
-    res.json::<serde_json::Value>().map_err(|e| e.to_string())
+    let v = res.json::<serde_json::Value>().map_err(|e| e.to_string())?;
+    if let Some(false) = v.get("ok").and_then(|x| x.as_bool()) {
+        let msg = v
+            .get("error")
+            .and_then(|x| x.as_str())
+            .unwrap_or("relay request failed");
+        return Err(format!("relay {path}: {msg}"));
+    }
+    Ok(v)
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,16 @@ use clap::{CommandFactory, Parser, Subcommand};
 use std::io::{self, IsTerminal};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+#[cfg(not(target_arch = "wasm32"))]
+use std::collections::HashMap;
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::{Arc, Mutex};
+#[cfg(not(target_arch = "wasm32"))]
+use tiny_http::{Method, Response, Server};
+#[cfg(not(target_arch = "wasm32"))]
+use serde_json::json;
+#[cfg(not(target_arch = "wasm32"))]
+use uuid::Uuid;
 use xos::apps::{AppCommands, run_app_command};
 use xos::python_api::{parse_script_cli_flags, run_python_app, run_python_file, run_python_interactive};
 
@@ -185,6 +195,16 @@ enum Commands {
     Off,
     #[command(name = "daemon-internal", hide = true)]
     DaemonInternal,
+    /// Run public online relay server for mode="online".
+    #[command(name = "relay")]
+    Relay {
+        /// Bind host (default: 0.0.0.0)
+        #[arg(long, default_value = "0.0.0.0")]
+        bind: String,
+        /// Bind port (default: 47333)
+        #[arg(long, default_value_t = 47333)]
+        port: u16,
+    },
 }
 
 /// ANSI orange (256-color) for `(uncommitted changes)` when stdout is a TTY.
@@ -341,6 +361,152 @@ fn resolve_python_file_path(file: &Path) -> Option<PathBuf> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Default)]
+struct RelayNode {
+    session_id: String,
+    node_hash_key: String,
+    rank: u32,
+    queue: Vec<serde_json::Value>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Default)]
+struct RelayMesh {
+    nodes: Vec<RelayNode>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Default)]
+struct RelayState {
+    meshes: HashMap<String, RelayMesh>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn run_relay_server(bind: &str, port: u16) {
+    let addr = format!("{bind}:{port}");
+    let server = match Server::http(addr.as_str()) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("❌ relay bind failed on {addr}: {e}");
+            std::process::exit(1);
+        }
+    };
+    println!("xos relay listening on http://{addr}");
+    let state = Arc::new(Mutex::new(RelayState::default()));
+    for mut req in server.incoming_requests() {
+        if req.method() != &Method::Post {
+            let _ = req.respond(Response::from_string("method not allowed").with_status_code(405));
+            continue;
+        }
+        let path = req.url().to_string();
+        let mut body = String::new();
+        let mut reader = req.as_reader();
+        let _ = std::io::Read::read_to_string(&mut reader, &mut body);
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap_or_else(|_| json!({}));
+        let resp = match path.as_str() {
+            "/mesh/connect" => {
+                let mesh_hash = v
+                    .get("mesh_hash_key")
+                    .and_then(|x| x.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let node_hash = v
+                    .get("node_hash_key")
+                    .and_then(|x| x.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if mesh_hash.is_empty() || node_hash.is_empty() {
+                    json!({"ok": false, "error": "mesh_hash_key and node_hash_key required"})
+                } else {
+                    let mut g = state.lock().unwrap();
+                    let mesh = g.meshes.entry(mesh_hash).or_default();
+                    mesh.nodes.retain(|n| n.node_hash_key != node_hash);
+                    let session_id = Uuid::new_v4().to_string();
+                    let rank = mesh.nodes.len() as u32;
+                    mesh.nodes.push(RelayNode {
+                        session_id: session_id.clone(),
+                        node_hash_key: node_hash,
+                        rank,
+                        queue: Vec::new(),
+                    });
+                    json!({"ok": true, "session_id": session_id, "rank": rank, "num_nodes": mesh.nodes.len()})
+                }
+            }
+            "/mesh/send" => {
+                let sid = v.get("session_id").and_then(|x| x.as_str()).unwrap_or("");
+                let to_rank = v.get("to_rank").and_then(|x| x.as_u64()).map(|x| x as u32);
+                let kind = v.get("kind").and_then(|x| x.as_str()).unwrap_or("").to_string();
+                let payload = v.get("payload").cloned().unwrap_or_else(|| json!({}));
+                let from_rank = v.get("from_rank").and_then(|x| x.as_u64()).unwrap_or(0) as u32;
+                let from_id = v.get("from_id").and_then(|x| x.as_str()).unwrap_or("").to_string();
+                let mut g = state.lock().unwrap();
+                let mut done = false;
+                for mesh in g.meshes.values_mut() {
+                    let sender_exists = mesh.nodes.iter().any(|n| n.session_id == sid);
+                    if !sender_exists {
+                        continue;
+                    }
+                    let msg = json!({
+                        "from_rank": from_rank,
+                        "from_id": from_id,
+                        "kind": kind,
+                        "payload": payload,
+                    });
+                    for n in &mut mesh.nodes {
+                        if n.session_id == sid {
+                            continue;
+                        }
+                        if let Some(t) = to_rank {
+                            if n.rank != t {
+                                continue;
+                            }
+                        }
+                        n.queue.push(msg.clone());
+                    }
+                    done = true;
+                    break;
+                }
+                if done { json!({"ok": true}) } else { json!({"ok": false, "error": "unknown session"}) }
+            }
+            "/mesh/poll" => {
+                let sid = v.get("session_id").and_then(|x| x.as_str()).unwrap_or("");
+                let mut g = state.lock().unwrap();
+                let mut out = json!({"ok": false, "error": "unknown session"});
+                for mesh in g.meshes.values_mut() {
+                    if let Some(node) = mesh.nodes.iter_mut().find(|n| n.session_id == sid) {
+                        let messages = std::mem::take(&mut node.queue);
+                        out = json!({
+                            "ok": true,
+                            "rank": node.rank,
+                            "num_nodes": mesh.nodes.len(),
+                            "messages": messages
+                        });
+                        break;
+                    }
+                }
+                out
+            }
+            "/mesh/disconnect" => {
+                let sid = v.get("session_id").and_then(|x| x.as_str()).unwrap_or("");
+                let mut g = state.lock().unwrap();
+                for mesh in g.meshes.values_mut() {
+                    if mesh.nodes.iter().any(|n| n.session_id == sid) {
+                        mesh.nodes.retain(|n| n.session_id != sid);
+                        for (idx, n) in mesh.nodes.iter_mut().enumerate() {
+                            n.rank = idx as u32;
+                        }
+                        break;
+                    }
+                }
+                json!({"ok": true})
+            }
+            _ => json!({"ok": false, "error": "unknown route"}),
+        };
+        let _ = req.respond(Response::from_string(resp.to_string()));
+    }
+}
+
 fn main() {
     let mut original_args: Vec<String> = std::env::args().collect();
 
@@ -379,6 +545,7 @@ fn main() {
                     | "status"
                     | "on"
                     | "off"
+                    | "relay"
                     | "daemon-internal"
                     | "-h"
                     | "--help"
@@ -413,6 +580,7 @@ fn main() {
                     | "status"
                     | "on"
                     | "off"
+                    | "relay"
                     | "daemon-internal"
                     | "-h"
                     | "--help"
@@ -657,6 +825,17 @@ fn main() {
         Some(Commands::DaemonInternal) => {
             if let Err(e) = daemon::run_daemon_forever() {
                 eprintln!("❌ daemon error: {e}");
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::Relay { bind, port }) => {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                run_relay_server(bind.as_str(), port);
+            }
+            #[cfg(target_arch = "wasm32")]
+            {
+                eprintln!("❌ relay is not available on wasm targets");
                 std::process::exit(1);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -421,7 +421,6 @@ fn run_relay_server(bind: &str, port: u16) {
                 } else {
                     let mut g = state.lock().unwrap();
                     let mesh = g.meshes.entry(mesh_hash).or_default();
-                    mesh.nodes.retain(|n| n.node_hash_key != node_hash);
                     let session_id = Uuid::new_v4().to_string();
                     let rank = mesh.nodes.len() as u32;
                     mesh.nodes.push(RelayNode {

--- a/src/py/ai.rs
+++ b/src/py/ai.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
+#[cfg(not(target_arch = "wasm32"))]
 use burn::tensor::DType;
+#[cfg(not(target_arch = "wasm32"))]
 use burn_store::{BurnpackStore, ModuleStore};
 use rustpython_vm::{AsObject, PyObjectRef, PyRef, PyResult, VirtualMachine, builtins::PyModule, function::FuncArgs};
 
@@ -151,6 +153,7 @@ fn resolve_weights_path(model: &str, override_path: Option<String>) -> Result<Pa
     ))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn whisper_load_payload(args: FuncArgs, vm: &VirtualMachine) -> PyResult {
     let av = args.args;
     let model = parse_string_arg(av.first(), "tiny", vm)?;
@@ -292,6 +295,14 @@ fn whisper_load_payload(args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         .set_item("parameters", params.as_object().to_owned(), vm)
         .ok();
     Ok(payload.into())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn whisper_load_payload(_args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    Err(to_py_err(
+        vm,
+        "Burn weight payload inspection is unavailable on wasm builds",
+    ))
 }
 
 fn whisper_forward_native(args: FuncArgs, vm: &VirtualMachine) -> PyResult {

--- a/src/py/mesh/bootstrap.py
+++ b/src/py/mesh/bootstrap.py
@@ -103,14 +103,12 @@ class _MeshNode:
 
 def connect(id="default", mode="local"):
     """Join a mesh. ``id`` selects the logical room (TCP + UDP discovery ports). ``mode`` is
-    ``local``, ``lan``, or ``online`` (``online`` raises until implemented). For ``lan``, run
+    ``local``, ``lan``, or ``online``. For ``lan``/``online``, run
     ``xos login --offline`` first so ``authentication.json`` and ``node_identity.json`` exist;
-    LAN uses the per-machine node keypair from ``node_identity.json`` (no password prompt).
+    both use the per-machine node keypair from ``node_identity.json`` (no password prompt).
     """
     mode = (mode or "local").lower()
-    if mode == "online":
-        raise NotImplementedError("xos.mesh mode 'online' is not implemented yet")
-    if mode not in ("local", "lan"):
+    if mode not in ("local", "lan", "online"):
         raise ValueError("xos.mesh.connect: mode must be 'local', 'lan', or 'online'")
     _mesh_connect(id, mode)
     return Mesh(id, mode)

--- a/src/py/mesh/mod.rs
+++ b/src/py/mesh/mod.rs
@@ -242,13 +242,7 @@ fn mesh_connect(args: FuncArgs, vm: &VirtualMachine) -> PyResult {
     let mode = match mode_str.as_str() {
         "local" => MeshMode::Local,
         "lan" => MeshMode::Lan,
-        "online" => {
-            return Err(vm.new_exception_msg(
-                vm.ctx.exceptions.not_implemented_error.to_owned(),
-                "xos.mesh mode 'online' is not implemented yet (and will require login identity)."
-                    .to_owned(),
-            ));
-        }
+        "online" => MeshMode::Online,
         _ => {
             return Err(vm.new_value_error(format!(
                 "xos.mesh.connect: unknown mode {mode_str:?} (use 'local', 'lan', or 'online')"
@@ -256,10 +250,10 @@ fn mesh_connect(args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         }
     };
 
-    let session = if mode == MeshMode::Lan {
+    let session = if mode == MeshMode::Lan || mode == MeshMode::Online {
         if !has_identity() {
             return Err(vm.new_runtime_error(
-                "xos.mesh.connect(mode='lan') requires a local login identity. Run `xos login` first."
+                "xos.mesh.connect(mode='lan'|'online') requires a local login identity. Run `xos login` first."
                     .to_string(),
             ));
         }

--- a/src/py/path.rs
+++ b/src/py/path.rs
@@ -32,7 +32,7 @@ pub fn make_path_module(vm: &VirtualMachine) -> PyRef<PyModule> {
     let m = vm.new_module("xos.path", vm.ctx.new_dict(), None);
     let _ = m.set_attr(
         "data",
-        vm.new_function("data", |vm: &VirtualMachine| {
+        vm.new_function("data", |vm: &VirtualMachine| -> PyResult<String> {
             Err(vm.new_runtime_error(
                 "xos.path.data: not available on wasm (pass explicit model paths)".to_string(),
             ))


### PR DESCRIPTION
1. Bring the mesh online (adding xos.xlate.ai as a relay server for mesh packets)
2. `xos relay` is how you can host a relay server, although soon we will want to do a WebRTC-style p2p server transport layer as well to save latency and packet costs.
3. fix --wasm compiler
4. add Dockerfile and integrate it into our release actions/versioning system
5. finally finish 0.3.17 publish release with .zip file for wasm in release files.