### PR TITLE
mesh upgrades for ios_remote visibility

### DIFF
--- a/src/core/apps/ios_remote.rs
+++ b/src/core/apps/ios_remote.rs
@@ -8,6 +8,12 @@ use crate::engine::{Application, EngineState};
     any(target_os = "windows", target_os = "macos", target_os = "linux")
 ))]
 use crate::engine::keyboard::shortcuts::{NamedSpecialKey, SpecialKeyEvent};
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "ios"),
+    any(target_os = "windows", target_os = "macos", target_os = "linux")
+))]
+use crate::rasterizer::text::{fonts, text_rasterization::TextRasterizer};
 use crate::rasterizer::fill;
 
 #[cfg(all(
@@ -67,6 +73,12 @@ pub struct IosRemoteApp {
         any(target_os = "windows", target_os = "macos", target_os = "linux")
     ))]
     session: Option<IosRemoteSession>,
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        not(target_os = "ios"),
+        any(target_os = "windows", target_os = "macos", target_os = "linux")
+    ))]
+    node_identity: Option<Arc<crate::auth::UnlockedNodeIdentity>>,
 }
 
 #[cfg(all(
@@ -89,6 +101,9 @@ struct IosRemoteSession {
     suppress_remote_mouse_buttons: bool,
     last_remote_nx: f32,
     last_remote_ny: f32,
+    disconnected_since: Option<Instant>,
+    last_rejoin_attempt_at: Option<Instant>,
+    status_text: TextRasterizer,
 }
 
 impl IosRemoteApp {
@@ -100,6 +115,12 @@ impl IosRemoteApp {
                 any(target_os = "windows", target_os = "macos", target_os = "linux")
             ))]
             session: None,
+            #[cfg(all(
+                not(target_arch = "wasm32"),
+                not(target_os = "ios"),
+                any(target_os = "windows", target_os = "macos", target_os = "linux")
+            ))]
+            node_identity: None,
         }
     }
 }
@@ -111,6 +132,18 @@ impl IosRemoteApp {
 ))]
 /// Top status bar height in window pixels (toolbar + stream toggle).
 const TOOLBAR_H: f32 = 42.0;
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "ios"),
+    any(target_os = "windows", target_os = "macos", target_os = "linux")
+))]
+const REMOTE_FRAME_STALL_TIMEOUT: Duration = Duration::from_millis(1400);
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "ios"),
+    any(target_os = "windows", target_os = "macos", target_os = "linux")
+))]
+const MESH_REJOIN_GAP: Duration = Duration::from_millis(1200);
 
 #[cfg(all(
     not(target_arch = "wasm32"),
@@ -256,6 +289,83 @@ fn outline_aspect_fit_abs(
     not(target_os = "ios"),
     any(target_os = "windows", target_os = "macos", target_os = "linux")
 ))]
+fn draw_status_center_message(
+    buffer: &mut [u8],
+    fw: usize,
+    fh: usize,
+    toolbar_h_px: usize,
+    rasterizer: &mut TextRasterizer,
+    text: &str,
+) {
+    if fw == 0 || fh == 0 || toolbar_h_px >= fh {
+        return;
+    }
+    let content_h = fh.saturating_sub(toolbar_h_px);
+    let us = ((fw.min(content_h) as f32) / 920.0).clamp(0.6, 1.7);
+    let font_size = (24.0 * us).clamp(16.0, 34.0);
+    rasterizer.set_font_size(font_size);
+    rasterizer.set_text(text.to_string());
+    rasterizer.tick(fw as f32, fh as f32);
+    let text_w: f32 = rasterizer
+        .characters
+        .iter()
+        .map(|c| c.metrics.advance_width)
+        .sum();
+    let text_h = font_size.max(1.0);
+    let cx = fw as f32 * 0.5;
+    let cy = toolbar_h_px as f32 + content_h as f32 * 0.5;
+    let tx = cx - text_w * 0.5;
+    let ty = cy - text_h * 0.5;
+    let pad_x = (18.0 * us) as usize;
+    let pad_y = (10.0 * us) as usize;
+    let x0 = tx.floor().max(0.0) as usize;
+    let y0 = ty.floor().max(toolbar_h_px as f32) as usize;
+    let x1 = (tx + text_w).ceil().min(fw as f32) as usize;
+    let y1 = (ty + text_h).ceil().min(fh as f32) as usize;
+    blit_solid_rect(
+        buffer,
+        fw,
+        fh,
+        x0.saturating_sub(pad_x),
+        y0.saturating_sub(pad_y),
+        (x1 + pad_x).min(fw),
+        (y1 + pad_y).min(fh),
+        (26, 31, 39),
+    );
+    for character in &rasterizer.characters {
+        let char_x = tx + character.x;
+        let char_y = ty + character.y;
+        let cw = character.width as usize;
+        if cw == 0 {
+            continue;
+        }
+        for (bitmap_y, row) in character.bitmap.chunks(cw).enumerate() {
+            for (bitmap_x, &alpha) in row.iter().enumerate() {
+                if alpha == 0 {
+                    continue;
+                }
+                let px = (char_x + bitmap_x as f32) as i32;
+                let py = (char_y + bitmap_y as f32) as i32;
+                if px < 0 || py < toolbar_h_px as i32 || px >= fw as i32 || py >= fh as i32 {
+                    continue;
+                }
+                let idx = ((py as usize * fw + px as usize) * 4) as usize;
+                let a = alpha as f32 / 255.0;
+                let ia = 1.0 - a;
+                buffer[idx] = (240.0 * a + buffer[idx] as f32 * ia) as u8;
+                buffer[idx + 1] = (242.0 * a + buffer[idx + 1] as f32 * ia) as u8;
+                buffer[idx + 2] = (248.0 * a + buffer[idx + 2] as f32 * ia) as u8;
+                buffer[idx + 3] = 0xff;
+            }
+        }
+    }
+}
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "ios"),
+    any(target_os = "windows", target_os = "macos", target_os = "linux")
+))]
 fn queue_and_send_input(
     s: &mut IosRemoteSession,
     mouse_x: f32,
@@ -311,6 +421,7 @@ fn queue_and_send_input(
 impl Application for IosRemoteApp {
     fn setup(&mut self, _state: &mut EngineState) -> Result<(), String> {
         let id = Arc::new(load_node_identity().map_err(|e| format!("{e}"))?);
+        self.node_identity = Some(Arc::clone(&id));
         let mesh = join_ios_remote_mesh_with_retries(&id)?;
         self.session = Some(IosRemoteSession {
             mesh,
@@ -325,6 +436,9 @@ impl Application for IosRemoteApp {
             suppress_remote_mouse_buttons: false,
             last_remote_nx: 0.5,
             last_remote_ny: 0.5,
+            disconnected_since: None,
+            last_rejoin_attempt_at: None,
+            status_text: TextRasterizer::new(fonts::default_font(), 24.0),
         });
         Ok(())
     }
@@ -346,13 +460,39 @@ impl Application for IosRemoteApp {
         let tb_i = (TOOLBAR_H.round() as usize).min(dst_h);
         let content_h = dst_h.saturating_sub(tb_i).max(1);
 
-        let nodes_ok = s.mesh.current_num_nodes() >= 2;
+        let now = Instant::now();
+        let mut nodes_ok = s.mesh.current_num_nodes() >= 2;
+        if !nodes_ok {
+            let can_retry = s
+                .last_rejoin_attempt_at
+                .map(|t| now.duration_since(t) >= MESH_REJOIN_GAP)
+                .unwrap_or(true);
+            if can_retry {
+                s.last_rejoin_attempt_at = Some(now);
+                if let Some(id) = self.node_identity.as_ref() {
+                    if let Ok(mesh) = join_ios_remote_mesh_with_retries(id) {
+                        s.mesh = mesh;
+                        s.last_rejoin_attempt_at = None;
+                        nodes_ok = s.mesh.current_num_nodes() >= 2;
+                    }
+                }
+            }
+        }
         let mut decoded = false;
 
         if !nodes_ok {
             s.has_frame = false;
+            s.disconnected_since.get_or_insert(now);
             state.f3_fps_label_override = None;
             fill(&mut state.frame, (18, 22, 28, 255));
+            draw_status_center_message(
+                state.frame_buffer_mut(),
+                dst_w,
+                dst_h,
+                tb_i,
+                &mut s.status_text,
+                "Connection lost - waiting for iOS app",
+            );
             draw_ios_remote_toolbar(state.frame_buffer_mut(), dst_w, dst_h, dst_w_f, s.receiver_wants_frames);
             queue_and_send_input(
                 s,
@@ -366,6 +506,7 @@ impl Application for IosRemoteApp {
             );
             return;
         }
+        s.disconnected_since = None;
 
         if s.receiver_wants_frames {
             if let Ok(Some(packets)) = s.mesh.inbox().receive(KIND_FRAME, false, true) {
@@ -450,6 +591,24 @@ impl Application for IosRemoteApp {
 
         if s.receiver_wants_frames && !decoded && !s.has_frame && content_h > 0 {
             blit_solid_rect(state.frame_buffer_mut(), dst_w, dst_h, 0, tb_i, dst_w, dst_h, (18, 22, 28));
+        }
+        if s.receiver_wants_frames && s.has_frame {
+            if let Some(last_frame_at) = s.last_remote_frame_at {
+                if now.duration_since(last_frame_at) > REMOTE_FRAME_STALL_TIMEOUT {
+                    state.f3_fps_label_override = None;
+                    blit_solid_rect(state.frame_buffer_mut(), dst_w, dst_h, 0, tb_i, dst_w, dst_h, (18, 22, 28));
+                    draw_status_center_message(
+                        state.frame_buffer_mut(),
+                        dst_w,
+                        dst_h,
+                        tb_i,
+                        &mut s.status_text,
+                        "Connection lost - waiting for iOS app",
+                    );
+                    s.has_frame = false;
+                    s.disconnected_since.get_or_insert(now);
+                }
+            }
         }
 
         draw_ios_remote_toolbar(state.frame_buffer_mut(), dst_w, dst_h, dst_w_f, s.receiver_wants_frames);

--- a/src/core/apps/ios_remote.rs
+++ b/src/core/apps/ios_remote.rs
@@ -462,7 +462,13 @@ impl Application for IosRemoteApp {
 
         let now = Instant::now();
         let mut nodes_ok = s.mesh.current_num_nodes() >= 2;
-        if !nodes_ok {
+        let stream_stalled = s.receiver_wants_frames
+            && s.has_frame
+            && s
+                .last_remote_frame_at
+                .map(|t| now.duration_since(t) > REMOTE_FRAME_STALL_TIMEOUT)
+                .unwrap_or(false);
+        if !nodes_ok || stream_stalled {
             let can_retry = s
                 .last_rejoin_attempt_at
                 .map(|t| now.duration_since(t) >= MESH_REJOIN_GAP)
@@ -474,6 +480,11 @@ impl Application for IosRemoteApp {
                         s.mesh = mesh;
                         s.last_rejoin_attempt_at = None;
                         nodes_ok = s.mesh.current_num_nodes() >= 2;
+                        if nodes_ok {
+                            s.has_frame = false;
+                            s.last_remote_frame_at = None;
+                            state.f3_fps_label_override = None;
+                        }
                     }
                 }
             }

--- a/src/core/apps/ios_remote.rs
+++ b/src/core/apps/ios_remote.rs
@@ -39,7 +39,7 @@ use std::sync::Arc;
     not(target_os = "ios"),
     any(target_os = "windows", target_os = "macos", target_os = "linux")
 ))]
-use std::time::Instant;
+use std::{thread, time::{Duration, Instant}};
 
 #[cfg(all(
     not(target_arch = "wasm32"),
@@ -83,6 +83,12 @@ struct IosRemoteSession {
     last_remote_frame_at: Option<Instant>,
     last_src_w: usize,
     last_src_h: usize,
+    /// When false, drop incoming JPEGs and ask the phone to stop broadcasting (see mesh JSON).
+    receiver_wants_frames: bool,
+    /// Toolbar/toggle interaction: do not forward click flags to the device until release.
+    suppress_remote_mouse_buttons: bool,
+    last_remote_nx: f32,
+    last_remote_ny: f32,
 }
 
 impl IosRemoteApp {
@@ -103,6 +109,153 @@ impl IosRemoteApp {
     not(target_os = "ios"),
     any(target_os = "windows", target_os = "macos", target_os = "linux")
 ))]
+/// Top status bar height in window pixels (toolbar + stream toggle).
+const TOOLBAR_H: f32 = 42.0;
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "ios"),
+    any(target_os = "windows", target_os = "macos", target_os = "linux")
+))]
+fn aspect_fit_rect(src_w: usize, src_h: usize, dst_w: usize, dst_h: usize) -> (usize, usize, usize, usize) {
+    if src_w == 0 || src_h == 0 || dst_w == 0 || dst_h == 0 {
+        return (0, 0, dst_w.max(1), dst_h.max(1));
+    }
+    let src_aspect = src_w as f32 / src_h as f32;
+    let dst_aspect = dst_w as f32 / dst_h as f32;
+    if src_aspect > dst_aspect {
+        let draw_w = dst_w;
+        let draw_h = ((draw_w as f32) / src_aspect).round().max(1.0) as usize;
+        let y = (dst_h.saturating_sub(draw_h)) / 2;
+        (0, y, draw_w, draw_h)
+    } else {
+        let draw_h = dst_h;
+        let draw_w = ((draw_h as f32) * src_aspect).round().max(1.0) as usize;
+        let x = (dst_w.saturating_sub(draw_w)) / 2;
+        (x, 0, draw_w, draw_h)
+    }
+}
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "ios"),
+    any(target_os = "windows", target_os = "macos", target_os = "linux")
+))]
+fn blit_solid_rect(buffer: &mut [u8], fw: usize, fh: usize, x0: usize, y0: usize, x1: usize, y1: usize, rgb: (u8, u8, u8)) {
+    let x1 = x1.min(fw);
+    let y1 = y1.min(fh);
+    if x0 >= x1 || y0 >= y1 {
+        return;
+    }
+    for y in y0..y1 {
+        let row = y * fw * 4;
+        for x in x0..x1 {
+            let i = row + x * 4;
+            buffer[i] = rgb.0;
+            buffer[i + 1] = rgb.1;
+            buffer[i + 2] = rgb.2;
+            buffer[i + 3] = 0xff;
+        }
+    }
+}
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "ios"),
+    any(target_os = "windows", target_os = "macos", target_os = "linux")
+))]
+/// Toggle hit region (stream on/off) inside the toolbar strip.
+fn stream_toggle_rect(dst_w: f32) -> (f32, f32, f32, f32) {
+    let tw = 54.0_f32;
+    let th = 26.0_f32;
+    let margin = 14.0_f32;
+    let x1 = dst_w - margin;
+    let x0 = x1 - tw;
+    let y0 = (TOOLBAR_H - th) * 0.5;
+    (x0, y0, x1, y0 + th)
+}
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "ios"),
+    any(target_os = "windows", target_os = "macos", target_os = "linux")
+))]
+fn draw_ios_remote_toolbar(buffer: &mut [u8], fw: usize, fh: usize, dst_w: f32, streaming: bool) {
+    let tb = (TOOLBAR_H.round() as usize).min(fh);
+    blit_solid_rect(buffer, fw, fh, 0, 0, fw, tb, (32, 34, 38));
+    blit_solid_rect(buffer, fw, fh, 0, tb.saturating_sub(1), fw, tb, (18, 76, 138));
+    let (tx0, ty0, tx1, ty1) = stream_toggle_rect(dst_w);
+    let ix0 = tx0.floor().max(0.0) as usize;
+    let iy0 = ty0.floor().max(0.0) as usize;
+    let ix1 = (tx1.ceil() as usize).min(fw);
+    let iy1 = (ty1.ceil() as usize).min(tb.min(fh.max(1)));
+    let track_rgb = if streaming {
+        (38, 120, 68)
+    } else {
+        (72, 72, 76)
+    };
+    let label_x0 = ix0.saturating_sub(136).max(12);
+    blit_solid_rect(buffer, fw, fh, label_x0, iy0, ix0, iy1, (44, 46, 50));
+    blit_solid_rect(buffer, fw, fh, ix0, iy0, ix1, iy1, track_rgb);
+    let knob_d = iy1.saturating_sub(iy0).saturating_sub(6).max(6);
+    let knob_y0 = iy0 + (iy1 - iy0).saturating_sub(knob_d) / 2;
+    let knob_x = if streaming {
+        ix1.saturating_sub(knob_d + 3)
+    } else {
+        ix0 + 3
+    };
+    let knob_x1 = (knob_x + knob_d).min(ix1);
+    let knob_x0 = knob_x.min(knob_x1.saturating_sub(knob_d));
+    blit_solid_rect(
+        buffer,
+        fw,
+        fh,
+        knob_x0,
+        knob_y0,
+        knob_x1,
+        knob_y0 + knob_d,
+        (235, 235, 238),
+    );
+}
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "ios"),
+    any(target_os = "windows", target_os = "macos", target_os = "linux")
+))]
+fn outline_aspect_fit_abs(
+    buffer: &mut [u8],
+    fw: usize,
+    fh: usize,
+    toolbar_i: usize,
+    src_w: usize,
+    src_h: usize,
+    content_h: usize,
+) {
+    if src_w == 0 || src_h == 0 || content_h == 0 {
+        return;
+    }
+    let (rx0, ry0, rw, rh) = aspect_fit_rect(src_w, src_h, fw, content_h);
+    let ax0 = rx0;
+    let ay0 = toolbar_i.saturating_add(ry0);
+    let ax1 = ax0.saturating_add(rw).min(fw);
+    let ay1 = ay0.saturating_add(rh).min(fh);
+    if ax0 >= ax1 || ay0 >= ay1 {
+        return;
+    }
+    let t = 3_usize;
+    let col = (0, 255, 208);
+    blit_solid_rect(buffer, fw, fh, ax0, ay0, ax1, ay0.saturating_add(t).min(ay1), col);
+    blit_solid_rect(buffer, fw, fh, ax0, ay1.saturating_sub(t).min(ay1), ax1, ay1, col);
+    blit_solid_rect(buffer, fw, fh, ax0, ay0, ax0.saturating_add(t).min(ax1), ay1, col);
+    blit_solid_rect(buffer, fw, fh, ax1.saturating_sub(t).min(ax1), ay0, ax1, ay1, col);
+}
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "ios"),
+    any(target_os = "windows", target_os = "macos", target_os = "linux")
+))]
 fn queue_and_send_input(
     s: &mut IosRemoteSession,
     mouse_x: f32,
@@ -111,28 +264,41 @@ fn queue_and_send_input(
     right_click: bool,
     dst_w: usize,
     dst_h: usize,
+    toolbar_h: f32,
 ) {
-    let (fit_x0, fit_y0, fit_w, fit_h) = if s.last_src_w > 0 && s.last_src_h > 0 {
-        aspect_fit_rect(s.last_src_w, s.last_src_h, dst_w, dst_h)
+    let ch = dst_h.saturating_sub(toolbar_h.round().max(0.0) as usize).max(1);
+    let in_content = mouse_y >= toolbar_h && !s.suppress_remote_mouse_buttons;
+
+    let (nx, ny) = if in_content && s.last_src_w > 0 && s.last_src_h > 0 {
+        let (fit_x0, fit_y0, fit_w, fit_h) = aspect_fit_rect(s.last_src_w, s.last_src_h, dst_w, ch);
+        let fit_wf = fit_w.max(1) as f32;
+        let fit_hf = fit_h.max(1) as f32;
+        let my_rel = mouse_y - toolbar_h;
+        let local_x = (mouse_x - fit_x0 as f32).clamp(0.0, fit_wf);
+        let local_y = (my_rel - fit_y0 as f32).clamp(0.0, fit_hf);
+        let nx = (local_x / fit_wf).clamp(0.0, 1.0);
+        let ny = (local_y / fit_hf).clamp(0.0, 1.0);
+        s.last_remote_nx = nx;
+        s.last_remote_ny = ny;
+        (nx, ny)
     } else {
-        (0, 0, dst_w.max(1), dst_h.max(1))
+        (s.last_remote_nx, s.last_remote_ny)
     };
-    let fit_wf = fit_w.max(1) as f32;
-    let fit_hf = fit_h.max(1) as f32;
-    let local_x = (mouse_x - fit_x0 as f32).clamp(0.0, fit_wf);
-    let local_y = (mouse_y - fit_y0 as f32).clamp(0.0, fit_hf);
-    let nx = (local_x / fit_wf).clamp(0.0, 1.0);
-    let ny = (local_y / fit_hf).clamp(0.0, 1.0);
+
+    let left_eff = left_click && !s.suppress_remote_mouse_buttons && in_content;
+    let right_eff = right_click && !s.suppress_remote_mouse_buttons && in_content;
+
     let scroll = f64::from(s.pending_scroll);
     s.pending_scroll = 0.0;
     let key_chars = std::mem::take(&mut s.pending_key_chars);
     let payload = json!({
         "nx": nx,
         "ny": ny,
-        "left": left_click,
-        "right": right_click,
+        "left": left_eff,
+        "right": right_eff,
         "scroll": scroll,
         "key_chars": key_chars,
+        "want_remote_frames": s.receiver_wants_frames,
     });
     let _ = s.mesh.broadcast_json(KIND_INPUT, payload);
 }
@@ -145,7 +311,7 @@ fn queue_and_send_input(
 impl Application for IosRemoteApp {
     fn setup(&mut self, _state: &mut EngineState) -> Result<(), String> {
         let id = Arc::new(load_node_identity().map_err(|e| format!("{e}"))?);
-        let mesh = MeshSession::join_with_identity(IOS_REMOTE_MESH_ID, MeshMode::Lan, id, None)?;
+        let mesh = join_ios_remote_mesh_with_retries(&id)?;
         self.session = Some(IosRemoteSession {
             mesh,
             pending_scroll: 0.0,
@@ -155,6 +321,10 @@ impl Application for IosRemoteApp {
             last_remote_frame_at: None,
             last_src_w: 0,
             last_src_h: 0,
+            receiver_wants_frames: true,
+            suppress_remote_mouse_buttons: false,
+            last_remote_nx: 0.5,
+            last_remote_ny: 0.5,
         });
         Ok(())
     }
@@ -172,70 +342,117 @@ impl Application for IosRemoteApp {
             return;
         }
 
-        if s.mesh.current_num_nodes() < 2 {
+        let dst_w_f = dst_w as f32;
+        let tb_i = (TOOLBAR_H.round() as usize).min(dst_h);
+        let content_h = dst_h.saturating_sub(tb_i).max(1);
+
+        let nodes_ok = s.mesh.current_num_nodes() >= 2;
+        let mut decoded = false;
+
+        if !nodes_ok {
             s.has_frame = false;
             state.f3_fps_label_override = None;
             fill(&mut state.frame, (18, 22, 28, 255));
-        } else if let Ok(Some(packets)) = s.mesh.inbox().receive(KIND_FRAME, false, true) {
-            if let Some(packet) = packets.last() {
-                if let Some(jpeg_b64) = packet.body.get("jpeg").and_then(|v| v.as_str()) {
-                    use base64::{engine::general_purpose::STANDARD as B64, Engine};
-                    if let Ok(bytes) = B64.decode(jpeg_b64.as_bytes()) {
-                        if let Ok(img) = image::load_from_memory(&bytes) {
-                            let rgba = img.to_rgba8();
-                            let sw = rgba.width() as usize;
-                            let sh = rgba.height() as usize;
-                            let buffer = state.frame_buffer_mut();
-                            buffer.fill(0);
-                            let (dx0, dy0, dw, dh) = aspect_fit_rect(sw, sh, dst_w, dst_h);
-                            let dw = dw.max(1);
-                            let dh = dh.max(1);
-                            let scaled = image::imageops::resize(
-                                &rgba,
-                                dw as u32,
-                                dh as u32,
-                                image::imageops::FilterType::Nearest,
-                            );
-                            let src_raw = scaled.as_raw();
-                            let cw = scaled.width() as usize;
-                            let ch = scaled.height() as usize;
-                            for y in 0..ch.min(dh) {
-                                let sx0 = y.saturating_mul(cw).saturating_mul(4);
-                                let row_len = cw.saturating_mul(4);
-                                if sx0 + row_len > src_raw.len() {
-                                    break;
-                                }
-                                let dy = dy0.saturating_add(y);
-                                if dy >= dst_h {
-                                    break;
-                                }
-                                let di0 = dy.saturating_mul(dst_w).saturating_add(dx0).saturating_mul(4);
-                                if di0 + row_len <= buffer.len() {
-                                    buffer[di0..di0 + row_len]
-                                        .copy_from_slice(&src_raw[sx0..sx0 + row_len]);
-                                }
+            draw_ios_remote_toolbar(state.frame_buffer_mut(), dst_w, dst_h, dst_w_f, s.receiver_wants_frames);
+            queue_and_send_input(
+                s,
+                state.mouse.x,
+                state.mouse.y,
+                state.mouse.is_left_clicking,
+                state.mouse.is_right_clicking,
+                dst_w,
+                dst_h,
+                TOOLBAR_H.min(dst_h as f32),
+            );
+            return;
+        }
+
+        if s.receiver_wants_frames {
+            if let Ok(Some(packets)) = s.mesh.inbox().receive(KIND_FRAME, false, true) {
+                if let Some(packet) = packets.last() {
+                    if let Some(jpeg_b64) = packet.body.get("jpeg").and_then(|v| v.as_str()) {
+                        use base64::{engine::general_purpose::STANDARD as B64, Engine};
+                        if let Ok(bytes) = B64.decode(jpeg_b64.as_bytes()) {
+                            if let Ok(img) = image::load_from_memory(&bytes) {
+                                let rgba = img.to_rgba8();
+                                let sw = rgba.width() as usize;
+                                let sh = rgba.height() as usize;
+                                let buffer = state.frame_buffer_mut();
+                                blit_solid_rect(buffer, dst_w, dst_h, 0, tb_i, dst_w, dst_h, (14, 16, 20));
+                                let (dx0, dy0, dw, dh) = aspect_fit_rect(sw, sh, dst_w, content_h);
+                                    let dw = dw.max(1);
+                                    let dh = dh.max(1);
+                                    let scaled = image::imageops::resize(
+                                        &rgba,
+                                        dw as u32,
+                                        dh as u32,
+                                        image::imageops::FilterType::Nearest,
+                                    );
+                                    let src_raw = scaled.as_raw();
+                                    let cw = scaled.width() as usize;
+                                    let sch = scaled.height() as usize;
+                                    for y in 0..sch.min(dh) {
+                                        let sx0 = y.saturating_mul(cw).saturating_mul(4);
+                                        let row_len = cw.saturating_mul(4);
+                                        if sx0 + row_len > src_raw.len() {
+                                            break;
+                                        }
+                                        let dy_abs = tb_i.saturating_add(dy0).saturating_add(y);
+                                        if dy_abs >= dst_h {
+                                            break;
+                                        }
+                                        let di0 = dy_abs
+                                            .saturating_mul(dst_w)
+                                            .saturating_add(dx0)
+                                            .saturating_mul(4);
+                                        if di0 + row_len <= buffer.len() {
+                                            buffer[di0..di0 + row_len]
+                                                .copy_from_slice(&src_raw[sx0..sx0 + row_len]);
+                                        }
+                                    }
+                                    s.has_frame = true;
+                                    s.last_src_w = sw;
+                                    s.last_src_h = sh;
+                                    let now = Instant::now();
+                                    if let Some(prev) = s.last_remote_frame_at.replace(now) {
+                                        let dt = now.duration_since(prev).as_secs_f32().max(1e-4);
+                                        let inst = 1.0 / dt;
+                                        s.remote_fps_ema = if s.remote_fps_ema <= 1e-6 {
+                                            inst
+                                        } else {
+                                            s.remote_fps_ema * 0.82 + inst * 0.18
+                                        };
+                                    }
+                                state.f3_fps_label_override =
+                                    Some(s.remote_fps_ema.clamp(0.0, 120.0));
+                                decoded = true;
                             }
-                            s.has_frame = true;
-                            s.last_src_w = sw;
-                            s.last_src_h = sh;
-                            let now = Instant::now();
-                            if let Some(prev) = s.last_remote_frame_at.replace(now) {
-                                let dt = now.duration_since(prev).as_secs_f32().max(1e-4);
-                                let inst = 1.0 / dt;
-                                s.remote_fps_ema = if s.remote_fps_ema <= 1e-6 {
-                                    inst
-                                } else {
-                                    s.remote_fps_ema * 0.82 + inst * 0.18
-                                };
-                            }
-                            state.f3_fps_label_override = Some(s.remote_fps_ema.clamp(0.0, 120.0));
                         }
                     }
                 }
             }
-        } else if !s.has_frame {
-            fill(&mut state.frame, (14, 16, 20, 255));
+        } else {
+            let _ = s.mesh.inbox().receive(KIND_FRAME, false, true);
+            state.f3_fps_label_override = None;
+            blit_solid_rect(state.frame_buffer_mut(), dst_w, dst_h, 0, tb_i, dst_w, dst_h, (22, 24, 30));
+            if s.has_frame && s.last_src_w > 0 && s.last_src_h > 0 && content_h > 0 {
+                outline_aspect_fit_abs(
+                    state.frame_buffer_mut(),
+                    dst_w,
+                    dst_h,
+                    tb_i,
+                    s.last_src_w,
+                    s.last_src_h,
+                    content_h,
+                );
+            }
         }
+
+        if s.receiver_wants_frames && !decoded && !s.has_frame && content_h > 0 {
+            blit_solid_rect(state.frame_buffer_mut(), dst_w, dst_h, 0, tb_i, dst_w, dst_h, (18, 22, 28));
+        }
+
+        draw_ios_remote_toolbar(state.frame_buffer_mut(), dst_w, dst_h, dst_w_f, s.receiver_wants_frames);
 
         queue_and_send_input(
             s,
@@ -245,11 +462,38 @@ impl Application for IosRemoteApp {
             state.mouse.is_right_clicking,
             dst_w,
             dst_h,
+            TOOLBAR_H.min(dst_h as f32),
         );
+    }
+
+    fn on_mouse_down(&mut self, state: &mut EngineState) {
+        let Some(s) = self.session.as_mut() else {
+            return;
+        };
+        let h = state.frame.shape()[0] as f32;
+        if state.mouse.y < TOOLBAR_H.min(h) {
+            s.suppress_remote_mouse_buttons = true;
+            let w = state.frame.shape()[1] as f32;
+            let (x0, y0, x1, y1) = stream_toggle_rect(w);
+            let mx = state.mouse.x;
+            let my = state.mouse.y;
+            if mx >= x0 && mx <= x1 && my >= y0 && my <= y1 {
+                s.receiver_wants_frames = !s.receiver_wants_frames;
+            }
+        }
+    }
+
+    fn on_mouse_up(&mut self, _: &mut EngineState) {
+        if let Some(s) = self.session.as_mut() {
+            s.suppress_remote_mouse_buttons = false;
+        }
     }
 
     fn on_scroll(&mut self, state: &mut EngineState, _dx: f32, dy: f32) {
         if state.paused {
+            return;
+        }
+        if state.mouse.y < TOOLBAR_H.min(state.frame.shape()[0] as f32) {
             return;
         }
         if let Some(s) = self.session.as_mut() {
@@ -290,23 +534,37 @@ impl Application for IosRemoteApp {
     not(target_os = "ios"),
     any(target_os = "windows", target_os = "macos", target_os = "linux")
 ))]
-fn aspect_fit_rect(src_w: usize, src_h: usize, dst_w: usize, dst_h: usize) -> (usize, usize, usize, usize) {
-    if src_w == 0 || src_h == 0 || dst_w == 0 || dst_h == 0 {
-        return (0, 0, dst_w.max(1), dst_h.max(1));
+const IOS_REMOTE_JOIN_ATTEMPTS: u32 = 8;
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "ios"),
+    any(target_os = "windows", target_os = "macos", target_os = "linux")
+))]
+const IOS_REMOTE_JOIN_GAP: Duration = Duration::from_millis(140);
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "ios"),
+    any(target_os = "windows", target_os = "macos", target_os = "linux")
+))]
+fn join_ios_remote_mesh_with_retries(
+    id: &Arc<crate::auth::UnlockedNodeIdentity>,
+) -> Result<MeshSession, String> {
+    let mode = match std::env::var("XOS_IOS_REMOTE_MESH").as_deref() {
+        Ok(s) if s.trim().eq_ignore_ascii_case("online") => MeshMode::Online,
+        _ => MeshMode::Lan,
+    };
+    let mut last_err = "ios-remote mesh: join gave no error detail".to_string();
+    for attempt in 0..IOS_REMOTE_JOIN_ATTEMPTS {
+        if attempt > 0 {
+            thread::sleep(IOS_REMOTE_JOIN_GAP);
+        }
+        match MeshSession::join_with_identity(IOS_REMOTE_MESH_ID, mode, Arc::clone(id), None) {
+            Ok(mesh) => return Ok(mesh),
+            Err(e) => last_err = e,
+        }
     }
-    let src_aspect = src_w as f32 / src_h as f32;
-    let dst_aspect = dst_w as f32 / dst_h as f32;
-    if src_aspect > dst_aspect {
-        let draw_w = dst_w;
-        let draw_h = ((draw_w as f32) / src_aspect).round().max(1.0) as usize;
-        let y = (dst_h.saturating_sub(draw_h)) / 2;
-        (0, y, draw_w, draw_h)
-    } else {
-        let draw_h = dst_h;
-        let draw_w = ((draw_h as f32) * src_aspect).round().max(1.0) as usize;
-        let x = (dst_w.saturating_sub(draw_w)) / 2;
-        (x, 0, draw_w, draw_h)
-    }
+    Err(last_err)
 }
 
 // Desktop-only deps are behind cfg above; this stub must compile on iOS/WASM/other so the app

--- a/src/core/crates/xos-java/src/lib.rs
+++ b/src/core/crates/xos-java/src/lib.rs
@@ -14,7 +14,6 @@ use xos::apps::coder::CoderApp;
 use xos::engine::{
     apply_frame_view_zoom,
     f3_menu_handle_mouse_down, f3_menu_handle_mouse_move, f3_menu_handle_mouse_up, tick_f3_menu,
-    tick_overlay_red_pointer,
     tick_frame_delta, tick_frame_view_zoom, Application, CursorStyleSetter, EngineState, F3Menu,
     FrameState, KeyboardState, MouseState, SafeRegionBoundingRectangle,
 };
@@ -137,7 +136,8 @@ pub extern "system" fn Java_ai_xlate_xos_XosNative_init(
             frame_view_center_x: 0.5,
             frame_view_center_y: 0.5,
             f3_fps_label_override: None,
-            overlay_red_pointer_enabled: true,
+            overlay_red_pointer_enabled: false,
+            overlay_red_pointer_radius: 0.0,
         };
 
         let mut app: Box<dyn Application> = Box::new(CoderApp::new());
@@ -217,7 +217,6 @@ pub extern "system" fn Java_ai_xlate_xos_XosNative_tick(mut env: JNIEnv, _class:
         }
 
         tick_f3_menu(&mut host.engine);
-        tick_overlay_red_pointer(&mut host.engine);
 
         let shape = host.engine.frame.shape();
         let w = shape[1];

--- a/src/core/crates/xos-java/src/lib.rs
+++ b/src/core/crates/xos-java/src/lib.rs
@@ -14,6 +14,7 @@ use xos::apps::coder::CoderApp;
 use xos::engine::{
     apply_frame_view_zoom,
     f3_menu_handle_mouse_down, f3_menu_handle_mouse_move, f3_menu_handle_mouse_up, tick_f3_menu,
+    tick_overlay_red_pointer,
     tick_frame_delta, tick_frame_view_zoom, Application, CursorStyleSetter, EngineState, F3Menu,
     FrameState, KeyboardState, MouseState, SafeRegionBoundingRectangle,
 };
@@ -136,6 +137,7 @@ pub extern "system" fn Java_ai_xlate_xos_XosNative_init(
             frame_view_center_x: 0.5,
             frame_view_center_y: 0.5,
             f3_fps_label_override: None,
+            overlay_red_pointer_enabled: true,
         };
 
         let mut app: Box<dyn Application> = Box::new(CoderApp::new());
@@ -215,6 +217,7 @@ pub extern "system" fn Java_ai_xlate_xos_XosNative_tick(mut env: JNIEnv, _class:
         }
 
         tick_f3_menu(&mut host.engine);
+        tick_overlay_red_pointer(&mut host.engine);
 
         let shape = host.engine.frame.shape();
         let w = shape[1];

--- a/src/core/engine/engine.rs
+++ b/src/core/engine/engine.rs
@@ -353,6 +353,8 @@ pub struct EngineState {
     /// When set, the F3 overlay shows this value as “FPS” instead of `1 / delta_time_seconds`
     /// (e.g. remote viewer reports actual stream frame rate).
     pub f3_fps_label_override: Option<f32>,
+    /// When true, composites a bright red dot at [`MouseState::x`]/[`MouseState::y`] after overlays (F3/OSK).
+    pub overlay_red_pointer_enabled: bool,
 }
 
 /// F3 scale bar range (slider maps linearly to multiplier `percent / 100`).

--- a/src/core/engine/engine.rs
+++ b/src/core/engine/engine.rs
@@ -353,8 +353,11 @@ pub struct EngineState {
     /// When set, the F3 overlay shows this value as “FPS” instead of `1 / delta_time_seconds`
     /// (e.g. remote viewer reports actual stream frame rate).
     pub f3_fps_label_override: Option<f32>,
-    /// When true, composites a bright red dot at [`MouseState::x`]/[`MouseState::y`] after overlays (F3/OSK).
+    /// When true (iOS **publisher** build only), composites a small red dot at [`MouseState::x`]/[`MouseState::y`]
+    /// after overlays so the mesh stream shows where the observer’s pointer lands.
     pub overlay_red_pointer_enabled: bool,
+    /// Pixel radius used when [`Self::overlay_red_pointer_enabled`] is true (typically ~3–4 on iOS streams).
+    pub overlay_red_pointer_radius: f32,
 }
 
 /// F3 scale bar range (slider maps linearly to multiplier `percent / 100`).

--- a/src/core/engine/f3_menu.rs
+++ b/src/core/engine/f3_menu.rs
@@ -23,7 +23,22 @@ const F3_INTERACTION_FADE_DECAY: f32 = 3.2;
 const FONT_OPTION_BASE_SIZE: f32 = 19.0;
 const FONT_HEADER_BASE_SIZE: f32 = 17.0;
 #[cfg(target_os = "ios")]
-const IOS_MESH_TOGGLE_LABEL_BASE_SIZE: f32 = 16.0;
+const IOS_MESH_HEADING_BASE_SIZE: f32 = 15.0;
+#[cfg(target_os = "ios")]
+const IOS_MESH_SEG_LABEL_BASE_SIZE: f32 = 16.0;
+/// Play/step hit targets scale vs prior layout (~10% larger for touch).
+const F3_CONTROL_BUTTON_SCALE: f32 = 1.1;
+
+#[cfg(target_os = "ios")]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum IosRemoteMeshTransport {
+    /// Do not join the ios-remote mesh (`ios-xos`).
+    Off,
+    /// LAN / UDP-discovery transport (matches desktop `ios-remote` default).
+    Lan,
+    /// Cloud relay mesh (requires login; desktop viewer: `XOS_IOS_REMOTE_MESH=online`).
+    Online,
+}
 
 pub struct F3Menu {
     /// When false, FPS is still tracked but the menu is not drawn. Toggle with F3 (desktop) or
@@ -36,9 +51,11 @@ pub struct F3Menu {
     font_option_families: Vec<FontFamily>,
     active_font_family: FontFamily,
     #[cfg(target_os = "ios")]
-    ios_mesh_toggle_rasterizer: TextRasterizer,
+    ios_mesh_heading_rasterizer: TextRasterizer,
     #[cfg(target_os = "ios")]
-    pub ios_mesh_enabled: bool,
+    ios_mesh_seg_rasterizers: [TextRasterizer; 3],
+    #[cfg(target_os = "ios")]
+    pub ios_mesh_transport: IosRemoteMeshTransport,
     pub(crate) scale_dragging: bool,
     /// Smooth wheel-zoom target in F3 percent units.
     scale_zoom_target: f32,
@@ -82,10 +99,18 @@ impl F3Menu {
             font_option_rasterizers.push(rasterizer);
         }
         #[cfg(target_os = "ios")]
-        let mut ios_mesh_toggle_rasterizer =
-            TextRasterizer::new(fonts::default_font(), IOS_MESH_TOGGLE_LABEL_BASE_SIZE);
+        let mut ios_mesh_heading_rasterizer =
+            TextRasterizer::new(fonts::default_font(), IOS_MESH_HEADING_BASE_SIZE);
         #[cfg(target_os = "ios")]
-        ios_mesh_toggle_rasterizer.set_text("iOS Mesh (ios-xos)".to_string());
+        ios_mesh_heading_rasterizer.set_text("iOS mesh (ios-xos)".to_string());
+        #[cfg(target_os = "ios")]
+        let seg_font = fonts::default_font();
+        #[cfg(target_os = "ios")]
+        let ios_mesh_seg_rasterizers = ["Off", "LAN", "Online"].map(|label| {
+            let mut r = TextRasterizer::new(seg_font.clone(), IOS_MESH_SEG_LABEL_BASE_SIZE);
+            r.set_text(label.to_string());
+            r
+        });
         Self {
             visible: false,
             fps_rasterizer,
@@ -95,9 +120,11 @@ impl F3Menu {
             font_option_families,
             active_font_family,
             #[cfg(target_os = "ios")]
-            ios_mesh_toggle_rasterizer,
+            ios_mesh_heading_rasterizer,
             #[cfg(target_os = "ios")]
-            ios_mesh_enabled: false,
+            ios_mesh_seg_rasterizers,
+            #[cfg(target_os = "ios")]
+            ios_mesh_transport: IosRemoteMeshTransport::Lan,
             scale_dragging: false,
             scale_zoom_target: 100.0,
             scale_zoom_value: 100.0,
@@ -148,6 +175,12 @@ struct PanelGeom {
     toggle_right: f32,
     toggle_top: f32,
     toggle_bottom: f32,
+    ios_mesh_heading_top: f32,
+    ios_mesh_heading_bottom: f32,
+    ios_mesh_seg_top: f32,
+    ios_mesh_seg_bottom: f32,
+    ios_mesh_seg_left: f32,
+    ios_mesh_seg_right: f32,
     font_option_count: usize,
     button_left: f32,
     button_right: f32,
@@ -184,9 +217,13 @@ fn panel_geom(
     let font_option_h = (26.0 * us).max(16.0);
     let font_option_gap = (4.0 * us).max(2.0);
     #[cfg(target_os = "ios")]
-    let toggle_h = (28.0 * us).max(18.0);
+    let mesh_heading_h = (17.0 * us).max(14.0);
+    #[cfg(target_os = "ios")]
+    let mesh_seg_h = (30.0 * us).max(22.0);
     #[cfg(not(target_os = "ios"))]
-    let toggle_h = 0.0_f32;
+    let mesh_heading_h = 0.0_f32;
+    #[cfg(not(target_os = "ios"))]
+    let mesh_seg_h = 0.0_f32;
     let font_options_h = if font_option_count == 0 {
         0.0
     } else {
@@ -203,14 +240,14 @@ fn panel_geom(
         0.0
     };
     #[cfg(target_os = "ios")]
-    let toggle_extra = line_gap + toggle_h;
+    let toggle_extra = line_gap + mesh_heading_h + line_gap + mesh_seg_h;
     #[cfg(not(target_os = "ios"))]
     let toggle_extra = 0.0_f32;
     let panel_h =
         pad + line_h + line_gap + line_h + line_gap + slider_h + font_extra + minimap_extra + toggle_extra + pad;
     let panel_left = w - panel_w - pad;
     let panel_top = safe_top + pad;
-    let button_size = (22.0 * us).max(12.0);
+    let button_size = ((22.0 * us).max(12.0)) * F3_CONTROL_BUTTON_SCALE;
     let button_gap = (6.0 * us).max(3.0);
     let step_right = panel_left + panel_w - pad;
     let step_left = step_right - button_size;
@@ -242,7 +279,31 @@ fn panel_geom(
     } else {
         slider_bottom + line_gap
     };
-    let toggle_bottom = toggle_top + toggle_h;
+    #[cfg(target_os = "ios")]
+    let ios_mesh_heading_top = toggle_top;
+    #[cfg(target_os = "ios")]
+    let ios_mesh_heading_bottom = toggle_top + mesh_heading_h;
+    #[cfg(target_os = "ios")]
+    let ios_mesh_seg_top = ios_mesh_heading_bottom + line_gap;
+    #[cfg(target_os = "ios")]
+    let ios_mesh_seg_bottom = ios_mesh_seg_top + mesh_seg_h;
+    #[cfg(target_os = "ios")]
+    let ios_mesh_seg_left = slider_left;
+    #[cfg(target_os = "ios")]
+    let ios_mesh_seg_right = slider_right;
+    #[cfg(target_os = "ios")]
+    let toggle_bottom = ios_mesh_seg_bottom;
+    #[cfg(not(target_os = "ios"))]
+    let (
+        ios_mesh_heading_top,
+        ios_mesh_heading_bottom,
+        ios_mesh_seg_top,
+        ios_mesh_seg_bottom,
+        ios_mesh_seg_left,
+        ios_mesh_seg_right,
+    ) = (0.0_f32, 0.0_f32, 0.0_f32, 0.0_f32, 0.0_f32, 0.0_f32);
+    #[cfg(not(target_os = "ios"))]
+    let toggle_bottom = toggle_top;
     PanelGeom {
         panel_left,
         panel_top,
@@ -261,6 +322,12 @@ fn panel_geom(
         toggle_right: slider_right,
         toggle_top,
         toggle_bottom,
+        ios_mesh_heading_top,
+        ios_mesh_heading_bottom,
+        ios_mesh_seg_top,
+        ios_mesh_seg_bottom,
+        ios_mesh_seg_left,
+        ios_mesh_seg_right,
         font_option_count,
         button_left,
         button_right,
@@ -325,10 +392,24 @@ fn sync_f3_default_font(menu: &mut F3Menu) {
     let mut scale = TextRasterizer::new(active_font.clone(), menu.scale_rasterizer.font_size);
     scale.set_text(menu.scale_rasterizer.text.clone());
     menu.scale_rasterizer = scale;
-    let mut header = TextRasterizer::new(active_font, menu.font_header_rasterizer.font_size);
+    let mut header = TextRasterizer::new(active_font.clone(), menu.font_header_rasterizer.font_size);
     header.set_text(menu.font_header_rasterizer.text.clone());
     menu.font_header_rasterizer = header;
     menu.active_font_family = current;
+    #[cfg(target_os = "ios")]
+    {
+        let mut h = TextRasterizer::new(active_font.clone(), menu.ios_mesh_heading_rasterizer.font_size);
+        h.set_text(menu.ios_mesh_heading_rasterizer.text.clone());
+        menu.ios_mesh_heading_rasterizer = h;
+        let labels = ["Off", "LAN", "Online"];
+        for (i, r) in menu.ios_mesh_seg_rasterizers.iter_mut().enumerate() {
+            if let Some(label) = labels.get(i) {
+                let mut nr = TextRasterizer::new(active_font.clone(), r.font_size);
+                nr.set_text((*label).to_string());
+                *r = nr;
+            }
+        }
+    }
 }
 
 #[inline]
@@ -475,11 +556,16 @@ fn measure_f3_panel(state: &mut EngineState) -> Option<(PanelGeom, f32)> {
         }
         #[cfg(target_os = "ios")]
         {
-            menu.ios_mesh_toggle_rasterizer
-                .set_font_size(IOS_MESH_TOGGLE_LABEL_BASE_SIZE * ui_scale);
-            menu.ios_mesh_toggle_rasterizer
-                .set_text("iOS Mesh (ios-xos)".to_string());
-            menu.ios_mesh_toggle_rasterizer.tick(width, height);
+            menu.ios_mesh_heading_rasterizer
+                .set_font_size(IOS_MESH_HEADING_BASE_SIZE * ui_scale);
+            menu
+                .ios_mesh_heading_rasterizer
+                .set_text("iOS mesh (ios-xos)".to_string());
+            menu.ios_mesh_heading_rasterizer.tick(width, height);
+            for r in menu.ios_mesh_seg_rasterizers.iter_mut() {
+                r.set_font_size(IOS_MESH_SEG_LABEL_BASE_SIZE * ui_scale);
+                r.tick(width, height);
+            }
         }
     }
 
@@ -497,7 +583,7 @@ fn measure_f3_panel(state: &mut EngineState) -> Option<(PanelGeom, f32)> {
         .iter()
         .map(|c| c.metrics.advance_width)
         .sum();
-    let button_size = (22.0 * ui_scale).max(12.0);
+    let button_size = ((22.0 * ui_scale).max(12.0)) * F3_CONTROL_BUTTON_SCALE;
     let button_gap = (6.0 * ui_scale).max(3.0);
     let slider_w = (200.0 * ui_scale).max(120.0);
     // Keep panel width stable so FPS/scale text width changes don't make the slider jitter horizontally.
@@ -563,13 +649,22 @@ pub fn f3_menu_handle_mouse_down(state: &mut EngineState) -> bool {
     }
     #[cfg(target_os = "ios")]
     {
-        let on_toggle = mx >= geom.toggle_left
-            && mx <= geom.toggle_right
-            && my >= geom.toggle_top
-            && my <= geom.toggle_bottom;
-        if on_toggle {
+        let on_mesh_seg = mx >= geom.ios_mesh_seg_left
+            && mx <= geom.ios_mesh_seg_right
+            && my >= geom.ios_mesh_seg_top
+            && my <= geom.ios_mesh_seg_bottom;
+        if on_mesh_seg {
             f3_menu_boost_interaction_fade(state);
-            state.f3_menu.ios_mesh_enabled = !state.f3_menu.ios_mesh_enabled;
+            let strip_w = (geom.ios_mesh_seg_right - geom.ios_mesh_seg_left).max(1.0);
+            let seg_w = strip_w / 3.0;
+            let rel = (mx - geom.ios_mesh_seg_left).clamp(0.0, strip_w - 1e-4);
+            let idx = (rel / seg_w).floor() as i32;
+            let idx = idx.clamp(0, 2) as usize;
+            state.f3_menu.ios_mesh_transport = match idx {
+                0 => IosRemoteMeshTransport::Off,
+                1 => IosRemoteMeshTransport::Lan,
+                _ => IosRemoteMeshTransport::Online,
+            };
             state.f3_menu.scale_dragging = false;
             state.f3_menu.pointer_captured = true;
             return true;
@@ -918,71 +1013,73 @@ pub fn tick_f3_menu(state: &mut EngineState) {
 
     #[cfg(target_os = "ios")]
     {
-        let tx0 = geom.toggle_left.floor() as i32;
-        let ty0 = geom.toggle_top.floor() as i32;
-        let tx1 = geom.toggle_right.ceil() as i32;
-        let ty1 = geom.toggle_bottom.ceil() as i32;
-        blend_rect(
-            buffer,
-            fw,
-            fh,
-            tx0,
-            ty0,
-            tx1,
-            ty1,
-            (46, 46, 52, (220.0 * overlay_alpha) as u8),
-        );
-
-        let toggle_w = (tx1 - tx0).max(8) as f32;
-        let toggle_h = (ty1 - ty0).max(8) as f32;
-        let switch_w = (toggle_w * 0.20).clamp(22.0, 40.0);
-        let switch_h = (toggle_h * 0.55).clamp(14.0, 24.0);
-        let switch_x1 = tx1 as f32 - (8.0 * geom.ui_scale);
-        let switch_x0 = switch_x1 - switch_w;
-        let switch_y0 = ty0 as f32 + (toggle_h - switch_h) * 0.5;
-        let switch_y1 = switch_y0 + switch_h;
-        let is_on = state.f3_menu.ios_mesh_enabled;
-        let track_col = if is_on {
-            (60, 150, 88, (230.0 * overlay_alpha) as u8)
-        } else {
-            (88, 88, 96, (220.0 * overlay_alpha) as u8)
-        };
-        blend_rect(
-            buffer,
-            fw,
-            fh,
-            switch_x0.floor() as i32,
-            switch_y0.floor() as i32,
-            switch_x1.ceil() as i32,
-            switch_y1.ceil() as i32,
-            track_col,
-        );
-        let knob_d = (switch_h - 4.0).max(8.0);
-        let knob_x = if is_on {
-            switch_x1 - knob_d - 2.0
-        } else {
-            switch_x0 + 2.0
-        };
-        blend_rect(
-            buffer,
-            fw,
-            fh,
-            knob_x.floor() as i32,
-            (switch_y0 + 2.0).floor() as i32,
-            (knob_x + knob_d).ceil() as i32,
-            (switch_y1 - 2.0).ceil() as i32,
-            (238, 238, 242, (255.0 * overlay_alpha) as u8),
-        );
         blend_text(
             buffer,
             width,
             height,
-            &state.f3_menu.ios_mesh_toggle_rasterizer,
-            geom.toggle_left + (8.0 * geom.ui_scale),
-            geom.toggle_top + ((geom.toggle_bottom - geom.toggle_top) * 0.23),
-            (245, 245, 245),
+            &state.f3_menu.ios_mesh_heading_rasterizer,
+            geom.ios_mesh_seg_left + (4.0 * geom.ui_scale),
+            geom.ios_mesh_heading_top + (2.0 * geom.ui_scale),
+            (220, 220, 226),
             overlay_alpha,
         );
+
+        let sx = geom.ios_mesh_seg_left;
+        let sy = geom.ios_mesh_seg_top;
+        let ex = geom.ios_mesh_seg_right;
+        let ey = geom.ios_mesh_seg_bottom;
+        let seg_row_y0 = sy.floor() as i32;
+        let seg_row_y1 = ey.ceil() as i32;
+
+        let strip_w = (ex - sx).max(1.0);
+        let seg_w = strip_w / 3.0;
+        let trans = state.f3_menu.ios_mesh_transport;
+
+        #[inline]
+        fn seg_selected(i: usize, t: IosRemoteMeshTransport) -> bool {
+            matches!(
+                (i, t),
+                (0, IosRemoteMeshTransport::Off)
+                    | (1, IosRemoteMeshTransport::Lan)
+                    | (2, IosRemoteMeshTransport::Online)
+            )
+        }
+
+        for i in 0..3 {
+            let sx0 = sx + i as f32 * seg_w;
+            let sx1 = sx0 + seg_w;
+            let ix0 = sx0.floor() as i32;
+            let ix1 = sx1.ceil() as i32;
+            let selected = seg_selected(i, trans);
+            let fill = if selected {
+                (52, 128, 78, (220.0 * overlay_alpha) as u8)
+            } else {
+                (48, 48, 54, (188.0 * overlay_alpha) as u8)
+            };
+            blend_rect(buffer, fw, fh, ix0, seg_row_y0, ix1, seg_row_y1, fill);
+        }
+
+        for (i, text_rasterizer) in state.f3_menu.ios_mesh_seg_rasterizers.iter().enumerate() {
+            let sx0 = sx + i as f32 * seg_w;
+            let text_w: f32 = text_rasterizer
+                .characters
+                .iter()
+                .map(|c| c.metrics.advance_width)
+                .sum();
+            let cell_w = seg_w.max(1.0);
+            let tx = sx0 + ((cell_w - text_w) * 0.5).max(3.0 * geom.ui_scale);
+            let ty = sy + ((ey - sy) - IOS_MESH_SEG_LABEL_BASE_SIZE * geom.ui_scale) * 0.32;
+            blend_text(
+                buffer,
+                width,
+                height,
+                text_rasterizer,
+                tx,
+                ty.max(sy + 2.0),
+                (246, 246, 250),
+                overlay_alpha,
+            );
+        }
     }
 
     let ui_scale = F3Menu::ui_scale(width.max(height));
@@ -1046,6 +1143,52 @@ pub fn tick_f3_menu(state: &mut EngineState) {
             (245, 245, 245),
             overlay_alpha,
         );
+    }
+}
+
+/// Solid red laser dot at the logical pointer (runs after keyboard + [`tick_f3_menu`]). Matches the
+/// OSK/trackpad cue used in [`crate::apps::text::TextApp`] but applies to **all** hosts.
+pub fn tick_overlay_red_pointer(state: &mut EngineState) {
+    if !state.overlay_red_pointer_enabled {
+        return;
+    }
+    let shape = state.frame.shape();
+    let fh = shape[0];
+    let fw = shape[1];
+    if fh == 0 || fw == 0 {
+        return;
+    }
+    let width_px = fw as f32;
+    let height_px = fh as f32;
+    let mx = state.mouse.x.round().clamp(0.0, width_px.max(1.0) - 1.0);
+    let my = state.mouse.y.round().clamp(0.0, height_px.max(1.0) - 1.0);
+    let buffer = state.frame.buffer_mut();
+    const DOT_RADIUS: f32 = 6.0;
+    let cx = mx as i32;
+    let cy = my as i32;
+    let rb = DOT_RADIUS.ceil() as i32;
+    for dy in -rb..=rb {
+        for dx in -rb..=rb {
+            let dist = ((dx * dx + dy * dy) as f32).sqrt();
+            if dist > DOT_RADIUS {
+                continue;
+            }
+            let px = cx + dx;
+            let py = cy + dy;
+            if px < 0 || py < 0 {
+                continue;
+            }
+            let px = px as usize;
+            let py = py as usize;
+            if px >= fw || py >= fh {
+                continue;
+            }
+            let idx = (py * fw + px) * 4;
+            buffer[idx] = 255;
+            buffer[idx + 1] = 0;
+            buffer[idx + 2] = 0;
+            buffer[idx + 3] = 0xff;
+        }
     }
 }
 

--- a/src/core/engine/f3_menu.rs
+++ b/src/core/engine/f3_menu.rs
@@ -1146,31 +1146,19 @@ pub fn tick_f3_menu(state: &mut EngineState) {
     }
 }
 
-/// Solid red laser dot at the logical pointer (runs after keyboard + [`tick_f3_menu`]). Matches the
-/// OSK/trackpad cue used in [`crate::apps::text::TextApp`] but applies to **all** hosts.
-pub fn tick_overlay_red_pointer(state: &mut EngineState) {
-    if !state.overlay_red_pointer_enabled {
-        return;
-    }
-    let shape = state.frame.shape();
-    let fh = shape[0];
-    let fw = shape[1];
-    if fh == 0 || fw == 0 {
-        return;
-    }
+#[inline]
+fn blend_red_dot_in_buffer(buffer: &mut [u8], fw: usize, fh: usize, mx: f32, my: f32, dot_radius: f32) {
     let width_px = fw as f32;
     let height_px = fh as f32;
-    let mx = state.mouse.x.round().clamp(0.0, width_px.max(1.0) - 1.0);
-    let my = state.mouse.y.round().clamp(0.0, height_px.max(1.0) - 1.0);
-    let buffer = state.frame.buffer_mut();
-    const DOT_RADIUS: f32 = 6.0;
+    let mx = mx.round().clamp(0.0, width_px.max(1.0) - 1.0);
+    let my = my.round().clamp(0.0, height_px.max(1.0) - 1.0);
     let cx = mx as i32;
     let cy = my as i32;
-    let rb = DOT_RADIUS.ceil() as i32;
+    let rb = dot_radius.ceil() as i32;
     for dy in -rb..=rb {
         for dx in -rb..=rb {
             let dist = ((dx * dx + dy * dy) as f32).sqrt();
-            if dist > DOT_RADIUS {
+            if dist > dot_radius {
                 continue;
             }
             let px = cx + dx;
@@ -1190,6 +1178,34 @@ pub fn tick_overlay_red_pointer(state: &mut EngineState) {
             buffer[idx + 3] = 0xff;
         }
     }
+}
+
+/// Small red stream cursor for the iOS **publisher** at explicit pixel coords (observer pointer from mesh),
+/// drawn after overlays and before JPEG capture so `ios-remote` sees it baked into pixels.
+#[inline]
+pub fn tick_overlay_red_pointer_xy(state: &mut EngineState, px: f32, py: f32) {
+    if !state.overlay_red_pointer_enabled {
+        return;
+    }
+    let shape = state.frame.shape();
+    let fh = shape[0];
+    let fw = shape[1];
+    if fh == 0 || fw == 0 {
+        return;
+    }
+    let buffer = state.frame.buffer_mut();
+    let dot_radius = state.overlay_red_pointer_radius.clamp(2.0, 10.0);
+    blend_red_dot_in_buffer(buffer, fw, fh, px, py, dot_radius);
+}
+
+/// Same as [`tick_overlay_red_pointer_xy`] using [`EngineState::mouse`] (caller handles mesh vs local).
+pub fn tick_overlay_red_pointer(state: &mut EngineState) {
+    if !state.overlay_red_pointer_enabled {
+        return;
+    }
+    let mx = state.mouse.x;
+    let my = state.mouse.y;
+    tick_overlay_red_pointer_xy(state, mx, my);
 }
 
 fn blend_text(

--- a/src/core/engine/ios_ffi.rs
+++ b/src/core/engine/ios_ffi.rs
@@ -220,6 +220,7 @@ pub extern "C" fn xos_engine_init(app_name: *const c_char, width: u32, height: u
         frame_view_center_y: 0.5,
         f3_fps_label_override: None,
         overlay_red_pointer_enabled: true,
+        overlay_red_pointer_radius: 3.5,
     };
 
     // Call setup
@@ -303,6 +304,10 @@ pub extern "C" fn xos_engine_tick() -> i32 {
         tick_frame_view_zoom(&mut ios_state.engine_state);
         apply_frame_view_zoom(&mut ios_state.engine_state);
 
+        // Observer (mesh) cursor for the streamed frame — before we restore finger coords for keyboard/F3.
+        let stream_cursor_x = ios_state.engine_state.mouse.x;
+        let stream_cursor_y = ios_state.engine_state.mouse.y;
+
         ios_state.engine_state.mouse.x = local_px;
         ios_state.engine_state.mouse.y = local_py;
         
@@ -328,8 +333,12 @@ pub extern "C" fn xos_engine_tick() -> i32 {
         }
 
         tick_f3_menu(&mut ios_state.engine_state);
+        crate::engine::tick_overlay_red_pointer_xy(
+            &mut ios_state.engine_state,
+            stream_cursor_x,
+            stream_cursor_y,
+        );
         tick_ios_remote_frame_push(ios_state);
-        crate::engine::tick_overlay_red_pointer(&mut ios_state.engine_state);
         
         // Swap R and B channels in-place for iOS Metal compatibility (RGBA -> BGRA)
         let frame_buffer = ios_state.engine_state.frame_buffer_mut();

--- a/src/core/engine/ios_ffi.rs
+++ b/src/core/engine/ios_ffi.rs
@@ -52,6 +52,10 @@ const IOS_REMOTE_FRAME_INTERVAL: Duration = Duration::from_nanos(16_666_667);
 #[cfg(target_os = "ios")]
 const IOS_REMOTE_RECONNECT_BACKOFF: Duration = Duration::from_millis(1400);
 #[cfg(target_os = "ios")]
+const IOS_REMOTE_CURSOR_HOLD: Duration = Duration::from_millis(160);
+#[cfg(target_os = "ios")]
+const IOS_LOCAL_INPUT_PRIORITY_HOLD: Duration = Duration::from_millis(220);
+#[cfg(target_os = "ios")]
 const IOS_REMOTE_STREAM_MAX_W: u32 = 720;
 #[cfg(target_os = "ios")]
 const IOS_REMOTE_JPEG_QUALITY: u8 = 50;
@@ -72,6 +76,10 @@ struct IosEngineState {
     ios_remote: Option<IosRemoteMeshState>,
     ios_remote_linked_mode: Option<MeshMode>,
     ios_remote_last_attempt: Option<Instant>,
+    /// Local iOS touch-down state (separate from remote observer packets).
+    local_touch_left_down: bool,
+    /// Short grace window where local touch/move remains authoritative over mesh input.
+    local_input_priority_until: Option<Instant>,
 }
 
 #[cfg(target_os = "ios")]
@@ -83,8 +91,14 @@ struct IosRemoteMeshState {
     last_frame_queued_at: Option<Instant>,
     prev_left: bool,
     prev_right: bool,
+    /// Most recent remote left-button state from mesh packets.
+    current_left: bool,
     /// Desktop viewer piggybacks this on mesh input packets; disables JPEG broadcast when false.
     viewer_wants_frames: bool,
+    /// Last observer pointer (from ios-remote mesh input), used for in-frame red-dot overlay.
+    stream_cursor_px: Option<(f32, f32)>,
+    /// Timestamp of the last observer pointer update.
+    stream_cursor_seen_at: Option<Instant>,
 }
 
 // Unsafe Send implementation - safe because iOS FFI is called from main thread only
@@ -220,7 +234,7 @@ pub extern "C" fn xos_engine_init(app_name: *const c_char, width: u32, height: u
         frame_view_center_y: 0.5,
         f3_fps_label_override: None,
         overlay_red_pointer_enabled: true,
-        overlay_red_pointer_radius: 3.5,
+        overlay_red_pointer_radius: 3.5 * 1.05,
     };
 
     // Call setup
@@ -237,6 +251,8 @@ pub extern "C" fn xos_engine_init(app_name: *const c_char, width: u32, height: u
         ios_remote: None,
         ios_remote_linked_mode: None,
         ios_remote_last_attempt: None,
+        local_touch_left_down: false,
+        local_input_priority_until: None,
     };
 
     let mut state = ENGINE_STATE.lock().unwrap();
@@ -304,9 +320,15 @@ pub extern "C" fn xos_engine_tick() -> i32 {
         tick_frame_view_zoom(&mut ios_state.engine_state);
         apply_frame_view_zoom(&mut ios_state.engine_state);
 
-        // Observer (mesh) cursor for the streamed frame — before we restore finger coords for keyboard/F3.
-        let stream_cursor_x = ios_state.engine_state.mouse.x;
-        let stream_cursor_y = ios_state.engine_state.mouse.y;
+        // Observer cursor comes only from ios-remote mesh packets (never from local finger touch).
+        let stream_cursor = ios_state.ios_remote.as_ref().and_then(|remote| {
+            let seen = remote.stream_cursor_seen_at?;
+            if seen.elapsed() <= IOS_REMOTE_CURSOR_HOLD {
+                remote.stream_cursor_px
+            } else {
+                None
+            }
+        });
 
         ios_state.engine_state.mouse.x = local_px;
         ios_state.engine_state.mouse.y = local_py;
@@ -333,11 +355,13 @@ pub extern "C" fn xos_engine_tick() -> i32 {
         }
 
         tick_f3_menu(&mut ios_state.engine_state);
-        crate::engine::tick_overlay_red_pointer_xy(
-            &mut ios_state.engine_state,
-            stream_cursor_x,
-            stream_cursor_y,
-        );
+        if let Some((stream_cursor_x, stream_cursor_y)) = stream_cursor {
+            crate::engine::tick_overlay_red_pointer_xy(
+                &mut ios_state.engine_state,
+                stream_cursor_x,
+                stream_cursor_y,
+            );
+        }
         tick_ios_remote_frame_push(ios_state);
         
         // Swap R and B channels in-place for iOS Metal compatibility (RGBA -> BGRA)
@@ -416,6 +440,10 @@ fn ensure_ios_remote_mesh_connected(state: &mut IosEngineState) {
         state.ios_remote = None;
         state.ios_remote_linked_mode = None;
         state.ios_remote_last_attempt = None;
+        state.engine_state.mouse.is_right_clicking = false;
+        if !state.local_touch_left_down {
+            state.engine_state.mouse.is_left_clicking = false;
+        }
         return;
     }
     let wanted_mode = wanted_mode.expect("wanted_mode checked");
@@ -427,6 +455,10 @@ fn ensure_ios_remote_mesh_connected(state: &mut IosEngineState) {
         state.ios_remote = None;
         state.ios_remote_linked_mode = None;
         state.ios_remote_last_attempt = None;
+        state.engine_state.mouse.is_right_clicking = false;
+        if !state.local_touch_left_down {
+            state.engine_state.mouse.is_left_clicking = false;
+        }
     }
 
     let now = Instant::now();
@@ -453,7 +485,10 @@ fn ensure_ios_remote_mesh_connected(state: &mut IosEngineState) {
                         last_frame_queued_at: None,
                         prev_left: false,
                         prev_right: false,
+                        current_left: false,
                         viewer_wants_frames: true,
+                        stream_cursor_px: None,
+                        stream_cursor_seen_at: None,
                     });
                 }
                 Err(e) => {
@@ -507,9 +542,34 @@ fn tick_ios_remote_input(state: &mut IosEngineState) {
     let ny = last.get("ny").and_then(|v| v.as_f64()).unwrap_or(0.0).clamp(0.0, 1.0);
     let left = last.get("left").and_then(|v| v.as_bool()).unwrap_or(false);
     let right = last.get("right").and_then(|v| v.as_bool()).unwrap_or(false);
+    remote.current_left = left;
 
     let mx = (nx as f32) * state.width as f32;
     let my = (ny as f32) * state.height as f32;
+    // Always track remote observer cursor for in-frame red-dot overlay,
+    // even when local touch is currently controlling app interaction.
+    remote.stream_cursor_px = Some((mx, my));
+    remote.stream_cursor_seen_at = Some(Instant::now());
+
+    // While local touch is active (or just happened), keep local drag/scroll authoritative.
+    // We still consume/remember remote button state so transitions don't backlog.
+    let local_input_priority = state.local_touch_left_down
+        || state
+            .local_input_priority_until
+            .map(|until| Instant::now() <= until)
+            .unwrap_or(false);
+    if local_input_priority {
+        remote.prev_left = left;
+        remote.prev_right = right;
+        remote.current_left = left;
+        if !chars_merged.is_empty() {
+            for ch in chars_merged.chars() {
+                state.app.on_key_char(&mut state.engine_state, ch);
+            }
+        }
+        return;
+    }
+
     let prev_x = state.engine_state.mouse.x;
     let prev_y = state.engine_state.mouse.y;
     state.engine_state.mouse.x = mx;
@@ -523,7 +583,7 @@ fn tick_ios_remote_input(state: &mut IosEngineState) {
     }
 
     if left != remote.prev_left {
-        state.engine_state.mouse.is_left_clicking = left;
+        state.engine_state.mouse.is_left_clicking = state.local_touch_left_down || left;
         if left {
             if !f3_menu_handle_mouse_down(&mut state.engine_state) {
                 state.app.on_mouse_down(&mut state.engine_state);
@@ -532,9 +592,8 @@ fn tick_ios_remote_input(state: &mut IosEngineState) {
             state.app.on_mouse_up(&mut state.engine_state);
         }
         remote.prev_left = left;
-    } else {
-        state.engine_state.mouse.is_left_clicking = left;
     }
+    state.engine_state.mouse.is_left_clicking = state.local_touch_left_down || left;
 
     if scroll_sum.abs() > f64::EPSILON {
         state
@@ -662,6 +721,7 @@ pub extern "C" fn xos_engine_update_mouse(x: f32, y: f32) -> i32 {
         ios_state.engine_state.mouse.y = y;
         ios_state.engine_state.mouse.dx = x - prev_x;
         ios_state.engine_state.mouse.dy = y - prev_y;
+        ios_state.local_input_priority_until = Some(Instant::now() + IOS_LOCAL_INPUT_PRIORITY_HOLD);
         
         if !f3_menu_handle_mouse_move(&mut ios_state.engine_state) {
             ios_state.app.on_mouse_move(&mut ios_state.engine_state);
@@ -682,6 +742,8 @@ pub extern "C" fn xos_engine_mouse_down() -> i32 {
     };
 
     if let Some(ref mut ios_state) = *state {
+        ios_state.local_touch_left_down = true;
+        ios_state.local_input_priority_until = Some(Instant::now() + IOS_LOCAL_INPUT_PRIORITY_HOLD);
         ios_state.engine_state.mouse.is_left_clicking = true;
         if !f3_menu_handle_mouse_down(&mut ios_state.engine_state) {
             ios_state.app.on_mouse_down(&mut ios_state.engine_state);
@@ -718,7 +780,14 @@ pub extern "C" fn xos_engine_mouse_up() -> i32 {
     };
 
     if let Some(ref mut ios_state) = *state {
-        ios_state.engine_state.mouse.is_left_clicking = false;
+        ios_state.local_touch_left_down = false;
+        ios_state.local_input_priority_until = Some(Instant::now() + IOS_LOCAL_INPUT_PRIORITY_HOLD);
+        let remote_left = ios_state
+            .ios_remote
+            .as_ref()
+            .map(|r| r.current_left)
+            .unwrap_or(false);
+        ios_state.engine_state.mouse.is_left_clicking = remote_left;
         if !f3_menu_handle_mouse_up(&mut ios_state.engine_state) {
             ios_state.app.on_mouse_up(&mut ios_state.engine_state);
         }
@@ -726,6 +795,75 @@ pub extern "C" fn xos_engine_mouse_up() -> i32 {
     } else {
         1
     }
+}
+
+/// Swap the active app without tearing down the engine.
+/// Returns 0 on success, non-zero on error.
+#[cfg(target_os = "ios")]
+#[no_mangle]
+pub extern "C" fn xos_engine_set_app(app_name: *const c_char) -> i32 {
+    let app_name_str = unsafe {
+        if app_name.is_null() {
+            return 2;
+        }
+        match std::ffi::CStr::from_ptr(app_name).to_str() {
+            Ok(s) => s,
+            Err(_) => return 3,
+        }
+    };
+
+    let mut state = match ENGINE_STATE.lock() {
+        Ok(s) => s,
+        Err(_) => return 1,
+    };
+    let Some(ios_state) = state.as_mut() else {
+        return 1;
+    };
+
+    let Some(mut next_app) = apps::get_app(app_name_str) else {
+        return 4;
+    };
+
+    ios_state.app.prepare_shutdown(&mut ios_state.engine_state);
+    ios_state.local_touch_left_down = false;
+    ios_state.local_input_priority_until = Some(Instant::now() + IOS_LOCAL_INPUT_PRIORITY_HOLD);
+    ios_state.engine_state.mouse.is_left_clicking = false;
+    ios_state.engine_state.mouse.is_right_clicking = false;
+    ios_state.engine_state.mouse.dx = 0.0;
+    ios_state.engine_state.mouse.dy = 0.0;
+    ios_state.last_tick_instant = None;
+
+    if let Err(e) = next_app.setup(&mut ios_state.engine_state) {
+        log_to_ios(&format!("xos_engine_set_app: setup failed for '{app_name_str}': {e}"));
+        return 5;
+    }
+
+    ios_state.app = next_app;
+    0
+}
+
+/// Configure iOS remote mesh transport directly.
+/// mode: 0=Off, 1=Lan, 2=Online.
+#[cfg(target_os = "ios")]
+#[no_mangle]
+pub extern "C" fn xos_engine_set_ios_remote_mesh_mode(mode: i32) -> i32 {
+    let mut state = match ENGINE_STATE.lock() {
+        Ok(s) => s,
+        Err(_) => return 1,
+    };
+    let Some(ios_state) = state.as_mut() else {
+        return 1;
+    };
+
+    let next_mode = match mode {
+        0 => IosRemoteMeshTransport::Off,
+        1 => IosRemoteMeshTransport::Lan,
+        2 => IosRemoteMeshTransport::Online,
+        _ => return 2,
+    };
+    ios_state.engine_state.f3_menu.ios_mesh_transport = next_mode;
+    ensure_ios_remote_mesh_connected(ios_state);
+    0
 }
 
 /// Resize the frame buffer

--- a/src/core/engine/ios_ffi.rs
+++ b/src/core/engine/ios_ffi.rs
@@ -538,8 +538,19 @@ fn tick_ios_remote_input(state: &mut IosEngineState) {
         .iter()
         .map(|p| p.body.get("scroll").and_then(|v| v.as_f64()).unwrap_or(0.0))
         .sum();
-    let nx = last.get("nx").and_then(|v| v.as_f64()).unwrap_or(0.0).clamp(0.0, 1.0);
-    let ny = last.get("ny").and_then(|v| v.as_f64()).unwrap_or(0.0).clamp(0.0, 1.0);
+    let fallback_nx = (state.engine_state.mouse.x / (state.width.max(1) as f32)).clamp(0.0, 1.0) as f64;
+    let fallback_ny = (state.engine_state.mouse.y / (state.height.max(1) as f32)).clamp(0.0, 1.0) as f64;
+    // Keep prior pointer position when malformed packets omit nx/ny; avoids jumps to (0,0).
+    let nx = last
+        .get("nx")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(fallback_nx)
+        .clamp(0.0, 1.0);
+    let ny = last
+        .get("ny")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(fallback_ny)
+        .clamp(0.0, 1.0);
     let left = last.get("left").and_then(|v| v.as_bool()).unwrap_or(false);
     let right = last.get("right").and_then(|v| v.as_bool()).unwrap_or(false);
     remote.current_left = left;

--- a/src/core/engine/ios_ffi.rs
+++ b/src/core/engine/ios_ffi.rs
@@ -28,6 +28,7 @@ use crate::engine::{
     apply_frame_view_zoom,
     f3_menu_handle_mouse_down, f3_menu_handle_mouse_move, f3_menu_handle_mouse_up, tick_f3_menu,
     tick_frame_delta, tick_frame_view_zoom, Application, EngineState, F3Menu, FrameState,
+    IosRemoteMeshTransport,
     KeyboardState, MouseState, SafeRegionBoundingRectangle,
 };
 #[cfg(target_os = "ios")]
@@ -69,6 +70,7 @@ struct IosEngineState {
     height: u32,
     last_tick_instant: Option<std::time::Instant>,
     ios_remote: Option<IosRemoteMeshState>,
+    ios_remote_linked_mode: Option<MeshMode>,
     ios_remote_last_attempt: Option<Instant>,
 }
 
@@ -81,6 +83,8 @@ struct IosRemoteMeshState {
     last_frame_queued_at: Option<Instant>,
     prev_left: bool,
     prev_right: bool,
+    /// Desktop viewer piggybacks this on mesh input packets; disables JPEG broadcast when false.
+    viewer_wants_frames: bool,
 }
 
 // Unsafe Send implementation - safe because iOS FFI is called from main thread only
@@ -215,6 +219,7 @@ pub extern "C" fn xos_engine_init(app_name: *const c_char, width: u32, height: u
         frame_view_center_x: 0.5,
         frame_view_center_y: 0.5,
         f3_fps_label_override: None,
+        overlay_red_pointer_enabled: true,
     };
 
     // Call setup
@@ -229,6 +234,7 @@ pub extern "C" fn xos_engine_init(app_name: *const c_char, width: u32, height: u
         height,
         last_tick_instant: None,
         ios_remote: None,
+        ios_remote_linked_mode: None,
         ios_remote_last_attempt: None,
     };
 
@@ -323,6 +329,7 @@ pub extern "C" fn xos_engine_tick() -> i32 {
 
         tick_f3_menu(&mut ios_state.engine_state);
         tick_ios_remote_frame_push(ios_state);
+        crate::engine::tick_overlay_red_pointer(&mut ios_state.engine_state);
         
         // Swap R and B channels in-place for iOS Metal compatibility (RGBA -> BGRA)
         let frame_buffer = ios_state.engine_state.frame_buffer_mut();
@@ -377,11 +384,11 @@ fn ios_remote_encoder_run(session: Arc<MeshSession>, rx: Receiver<(u32, u32, Vec
 }
 
 #[cfg(target_os = "ios")]
-fn try_connect_ios_remote_mesh() -> Result<Arc<MeshSession>, String> {
+fn try_connect_ios_remote_mesh(mode: MeshMode) -> Result<Arc<MeshSession>, String> {
     let node_identity = load_node_identity().map_err(|e| format!("node identity unavailable: {e}"))?;
     let session = MeshSession::join_with_identity(
         IOS_REMOTE_MESH_ID,
-        MeshMode::Lan,
+        mode,
         Arc::new(node_identity),
         None,
     )?;
@@ -390,13 +397,29 @@ fn try_connect_ios_remote_mesh() -> Result<Arc<MeshSession>, String> {
 
 #[cfg(target_os = "ios")]
 fn ensure_ios_remote_mesh_connected(state: &mut IosEngineState) {
-    if !state.engine_state.f3_menu.ios_mesh_enabled {
+    let wanted_mode = match state.engine_state.f3_menu.ios_mesh_transport {
+        IosRemoteMeshTransport::Off => None,
+        IosRemoteMeshTransport::Lan => Some(MeshMode::Lan),
+        IosRemoteMeshTransport::Online => Some(MeshMode::Online),
+    };
+
+    if wanted_mode.is_none() {
         state.ios_remote = None;
+        state.ios_remote_linked_mode = None;
+        state.ios_remote_last_attempt = None;
+        return;
+    }
+    let wanted_mode = wanted_mode.expect("wanted_mode checked");
+
+    if state.ios_remote_linked_mode == Some(wanted_mode) && state.ios_remote.is_some() {
         return;
     }
     if state.ios_remote.is_some() {
-        return;
+        state.ios_remote = None;
+        state.ios_remote_linked_mode = None;
+        state.ios_remote_last_attempt = None;
     }
+
     let now = Instant::now();
     if let Some(last) = state.ios_remote_last_attempt {
         if now.duration_since(last) < IOS_REMOTE_RECONNECT_BACKOFF {
@@ -404,7 +427,7 @@ fn ensure_ios_remote_mesh_connected(state: &mut IosEngineState) {
         }
     }
     state.ios_remote_last_attempt = Some(now);
-    match try_connect_ios_remote_mesh() {
+    match try_connect_ios_remote_mesh(wanted_mode) {
         Ok(session) => {
             let (frame_tx, frame_rx) = sync_channel::<(u32, u32, Vec<u8>)>(1);
             let session_for_enc = Arc::clone(&session);
@@ -413,6 +436,7 @@ fn ensure_ios_remote_mesh_connected(state: &mut IosEngineState) {
                 .spawn(move || ios_remote_encoder_run(session_for_enc, frame_rx));
             match join_result {
                 Ok(_encoder_join) => {
+                    state.ios_remote_linked_mode = Some(wanted_mode);
                     state.ios_remote = Some(IosRemoteMeshState {
                         session,
                         frame_tx,
@@ -420,15 +444,18 @@ fn ensure_ios_remote_mesh_connected(state: &mut IosEngineState) {
                         last_frame_queued_at: None,
                         prev_left: false,
                         prev_right: false,
+                        viewer_wants_frames: true,
                     });
                 }
                 Err(e) => {
                     log_to_ios(&format!("ios-remote: encoder thread spawn failed: {e}"));
+                    state.ios_remote_linked_mode = None;
                 }
             }
         }
         Err(e) => {
             log_to_ios(&format!("ios-remote: mesh connect failed: {e}"));
+            state.ios_remote_linked_mode = None;
         }
     }
 }
@@ -458,6 +485,11 @@ fn tick_ios_remote_input(state: &mut IosEngineState) {
     }
 
     let last = packets.last().map(|p| p.body.clone()).unwrap_or_else(|| json!({}));
+
+    if let Some(wf) = last.get("want_remote_frames").and_then(|v| v.as_bool()) {
+        remote.viewer_wants_frames = wf;
+    }
+
     let scroll_sum: f64 = packets
         .iter()
         .map(|p| p.body.get("scroll").and_then(|v| v.as_f64()).unwrap_or(0.0))
@@ -514,6 +546,9 @@ fn tick_ios_remote_frame_push(state: &mut IosEngineState) {
     let Some(remote) = state.ios_remote.as_mut() else {
         return;
     };
+    if !remote.viewer_wants_frames {
+        return;
+    }
     if remote.session.current_num_nodes() < 2 {
         return;
     }

--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -36,6 +36,7 @@ pub use f3_menu::{
     f3_menu_handle_frame_zoom_scroll,
     f3_menu_handle_mouse_down, f3_menu_handle_mouse_move, f3_menu_handle_mouse_up,
     f3_menu_handle_zoom_scroll, tick_f3_menu, tick_overlay_red_pointer,
+    tick_overlay_red_pointer_xy,
     F3Menu,
 };
 #[cfg(target_os = "ios")]

--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -35,9 +35,11 @@ pub use f3_menu::{
     f3_menu_boost_interaction_fade,
     f3_menu_handle_frame_zoom_scroll,
     f3_menu_handle_mouse_down, f3_menu_handle_mouse_move, f3_menu_handle_mouse_up,
-    f3_menu_handle_zoom_scroll, tick_f3_menu,
+    f3_menu_handle_zoom_scroll, tick_f3_menu, tick_overlay_red_pointer,
     F3Menu,
 };
+#[cfg(target_os = "ios")]
+pub use f3_menu::IosRemoteMeshTransport;
 pub use engine::{
     apply_frame_view_zoom, f3_ui_scale_multiplier, frame_view_pan_by_pixels,
     frame_view_rect_norm, tick_frame_delta, tick_frame_view_zoom, Application,

--- a/src/core/engine/native_engine.rs
+++ b/src/core/engine/native_engine.rs
@@ -20,7 +20,7 @@ use super::{
     f3_menu_boost_interaction_fade,
     f3_menu_handle_frame_zoom_scroll,
     f3_menu_handle_mouse_down, f3_menu_handle_mouse_move, f3_menu_handle_mouse_up,
-    f3_menu_handle_zoom_scroll, tick_f3_menu, tick_overlay_red_pointer,
+    f3_menu_handle_zoom_scroll, tick_f3_menu,
     frame_view_pan_by_pixels,
     tick_frame_view_zoom,
     F3Menu,
@@ -236,7 +236,6 @@ impl AppState {
         }
 
         tick_f3_menu(&mut self.engine_state);
-        tick_overlay_red_pointer(&mut self.engine_state);
 
         if mirror_ok {
             self.engine_state.frame.clear_pixels_mirror_buffer();
@@ -677,7 +676,8 @@ impl ApplicationHandler for AppStateWrapper {
                 frame_view_center_x: 0.5,
                 frame_view_center_y: 0.5,
                 f3_fps_label_override: None,
-                overlay_red_pointer_enabled: true,
+                overlay_red_pointer_enabled: false,
+                overlay_red_pointer_radius: 0.0,
             };
 
             if let Err(e) = self.app.setup(&mut engine_state) {
@@ -812,7 +812,8 @@ pub fn start_headless_native(
         frame_view_center_x: 0.5,
         frame_view_center_y: 0.5,
         f3_fps_label_override: None,
-        overlay_red_pointer_enabled: true,
+        overlay_red_pointer_enabled: false,
+        overlay_red_pointer_radius: 0.0,
     };
 
     if let Err(e) = app.setup(&mut engine_state) {
@@ -835,7 +836,6 @@ pub fn start_headless_native(
             app.tick(&mut engine_state);
         }
         tick_f3_menu(&mut engine_state);
-        tick_overlay_red_pointer(&mut engine_state);
     }
     SHOULD_EXIT.store(false, Ordering::Relaxed);
     Ok(())

--- a/src/core/engine/native_engine.rs
+++ b/src/core/engine/native_engine.rs
@@ -20,7 +20,7 @@ use super::{
     f3_menu_boost_interaction_fade,
     f3_menu_handle_frame_zoom_scroll,
     f3_menu_handle_mouse_down, f3_menu_handle_mouse_move, f3_menu_handle_mouse_up,
-    f3_menu_handle_zoom_scroll, tick_f3_menu,
+    f3_menu_handle_zoom_scroll, tick_f3_menu, tick_overlay_red_pointer,
     frame_view_pan_by_pixels,
     tick_frame_view_zoom,
     F3Menu,
@@ -236,6 +236,7 @@ impl AppState {
         }
 
         tick_f3_menu(&mut self.engine_state);
+        tick_overlay_red_pointer(&mut self.engine_state);
 
         if mirror_ok {
             self.engine_state.frame.clear_pixels_mirror_buffer();
@@ -676,6 +677,7 @@ impl ApplicationHandler for AppStateWrapper {
                 frame_view_center_x: 0.5,
                 frame_view_center_y: 0.5,
                 f3_fps_label_override: None,
+                overlay_red_pointer_enabled: true,
             };
 
             if let Err(e) = self.app.setup(&mut engine_state) {
@@ -810,6 +812,7 @@ pub fn start_headless_native(
         frame_view_center_x: 0.5,
         frame_view_center_y: 0.5,
         f3_fps_label_override: None,
+        overlay_red_pointer_enabled: true,
     };
 
     if let Err(e) = app.setup(&mut engine_state) {
@@ -832,6 +835,7 @@ pub fn start_headless_native(
             app.tick(&mut engine_state);
         }
         tick_f3_menu(&mut engine_state);
+        tick_overlay_red_pointer(&mut engine_state);
     }
     SHOULD_EXIT.store(false, Ordering::Relaxed);
     Ok(())

--- a/src/core/engine/wasm_engine.rs
+++ b/src/core/engine/wasm_engine.rs
@@ -9,7 +9,7 @@ use super::{
     f3_menu_boost_interaction_fade,
     f3_menu_handle_frame_zoom_scroll,
     f3_menu_handle_mouse_down, f3_menu_handle_mouse_move, f3_menu_handle_mouse_up,
-    f3_menu_handle_zoom_scroll, tick_f3_menu,
+    f3_menu_handle_zoom_scroll, tick_f3_menu, tick_overlay_red_pointer,
     frame_view_pan_by_pixels,
     tick_frame_view_zoom,
     F3Menu,
@@ -87,6 +87,7 @@ pub fn run_web(app: Box<dyn Application>) -> Result<(), JsValue> {
             frame_view_center_x: 0.5,
             frame_view_center_y: 0.5,
             f3_fps_label_override: None,
+            overlay_red_pointer_enabled: true,
         },
         app,
         command_held: false,
@@ -554,6 +555,7 @@ pub fn run_web(app: Box<dyn Application>) -> Result<(), JsValue> {
                 }
 
                 tick_f3_menu(&mut state.engine_state);
+                tick_overlay_red_pointer(&mut state.engine_state);
                 
                 // Render to canvas
                 let buffer = state.engine_state.frame_buffer_mut();

--- a/src/core/engine/wasm_engine.rs
+++ b/src/core/engine/wasm_engine.rs
@@ -9,7 +9,7 @@ use super::{
     f3_menu_boost_interaction_fade,
     f3_menu_handle_frame_zoom_scroll,
     f3_menu_handle_mouse_down, f3_menu_handle_mouse_move, f3_menu_handle_mouse_up,
-    f3_menu_handle_zoom_scroll, tick_f3_menu, tick_overlay_red_pointer,
+    f3_menu_handle_zoom_scroll, tick_f3_menu,
     frame_view_pan_by_pixels,
     tick_frame_view_zoom,
     F3Menu,
@@ -87,7 +87,8 @@ pub fn run_web(app: Box<dyn Application>) -> Result<(), JsValue> {
             frame_view_center_x: 0.5,
             frame_view_center_y: 0.5,
             f3_fps_label_override: None,
-            overlay_red_pointer_enabled: true,
+            overlay_red_pointer_enabled: false,
+            overlay_red_pointer_radius: 0.0,
         },
         app,
         command_held: false,
@@ -555,7 +556,6 @@ pub fn run_web(app: Box<dyn Application>) -> Result<(), JsValue> {
                 }
 
                 tick_f3_menu(&mut state.engine_state);
-                tick_overlay_red_pointer(&mut state.engine_state);
                 
                 // Render to canvas
                 let buffer = state.engine_state.frame_buffer_mut();

--- a/src/core/lib.rs
+++ b/src/core/lib.rs
@@ -92,19 +92,29 @@ fn project_root_from_target_executable(exe: &Path) -> Option<PathBuf> {
     }
 }
 
+/// Symlink- and `/var`↔`/private/var`-stable root so `target/standard` (and other isolated dirs) do
+/// not split across two paths when the repo is found via [`std::env::current_dir`] vs
+/// [`std::env::current_exe`] (e.g. `cd ~/clone` vs running `target/standard/release/xos`).
+fn normalize_repo_root(p: PathBuf) -> PathBuf {
+    match fs::canonicalize(&p) {
+        Ok(c) => c,
+        Err(_) => p,
+    }
+}
+
 /// Locate the xos repo: the repo containing a `target/.../release|debug` `xos` binary (when that is
 /// what is running), else walk parents of the executable, then compile-time
 /// [`CARGO_MANIFEST_DIR`] (for `cargo install` copies), then walk up from [`std::env::current_dir`].
 pub fn find_xos_project_root() -> Result<PathBuf, String> {
     if let Ok(exe) = std::env::current_exe() {
         if let Some(root) = project_root_from_target_executable(&exe) {
-            return Ok(root);
+            return Ok(normalize_repo_root(root));
         }
         let mut opt = exe.parent().map(PathBuf::from);
         for _ in 0..16 {
             if let Some(ref dir) = opt {
                 if is_xos_project_root(dir) {
-                    return Ok(dir.clone());
+                    return Ok(normalize_repo_root(dir.clone()));
                 }
                 opt = dir.parent().map(PathBuf::from);
             } else {
@@ -116,7 +126,7 @@ pub fn find_xos_project_root() -> Result<PathBuf, String> {
     if let Some(dir) = option_env!("CARGO_MANIFEST_DIR") {
         let p = PathBuf::from(dir);
         if is_xos_project_root(&p) {
-            return Ok(p);
+            return Ok(normalize_repo_root(p));
         }
     }
 
@@ -124,11 +134,11 @@ pub fn find_xos_project_root() -> Result<PathBuf, String> {
         std::env::current_dir().map_err(|e| format!("current_dir: {e}"))?;
     loop {
         if is_xos_project_root(&current) {
-            return Ok(current);
+            return Ok(normalize_repo_root(current));
         }
         let xos_sub = current.join("xos");
         if is_xos_project_root(&xos_sub) {
-            return Ok(xos_sub);
+            return Ok(normalize_repo_root(xos_sub));
         }
         match current.parent() {
             Some(parent) => current = parent.to_path_buf(),

--- a/src/ios/XosModule/XosViewportView.swift
+++ b/src/ios/XosModule/XosViewportView.swift
@@ -192,11 +192,11 @@ public class XosViewportView: UIView {
     }
     
     /// Same role as **F3** on desktop: toggles FPS / UI scale (`f3_menu`). Three-finger **hold**
-    /// (~0.85s), similar in spirit to Expo’s dev-menu gesture.
+    /// (~0.64s), similar in spirit to Expo’s dev-menu gesture.
     private func setupThreeFingerF3Gesture() {
         let gr = UILongPressGestureRecognizer(target: self, action: #selector(handleThreeFingerF3LongPress(_:)))
         gr.numberOfTouchesRequired = 3
-        gr.minimumPressDuration = 0.85
+        gr.minimumPressDuration = 0.6375
         gr.cancelsTouchesInView = true
         addGestureRecognizer(gr)
     }

--- a/src/py/xos_module.rs
+++ b/src/py/xos_module.rs
@@ -164,7 +164,8 @@ impl StandalonePreviewApp {
                     frame_view_center_x: 0.5,
                     frame_view_center_y: 0.5,
                     f3_fps_label_override: None,
-                    overlay_red_pointer_enabled: true,
+                    overlay_red_pointer_enabled: false,
+                    overlay_red_pointer_radius: 0.0,
                 },
             );
             self.last_tick_instant.insert(viewport_id, None);
@@ -275,7 +276,6 @@ impl StandalonePreviewApp {
                     crate::engine::tick_frame_view_zoom(es);
                     crate::engine::apply_frame_view_zoom(es);
                     crate::engine::tick_f3_menu(es);
-                    crate::engine::tick_overlay_red_pointer(es);
                     frame_data.rgba.copy_from_slice(es.frame.buffer_mut());
                 }
             }

--- a/src/py/xos_module.rs
+++ b/src/py/xos_module.rs
@@ -164,6 +164,7 @@ impl StandalonePreviewApp {
                     frame_view_center_x: 0.5,
                     frame_view_center_y: 0.5,
                     f3_fps_label_override: None,
+                    overlay_red_pointer_enabled: true,
                 },
             );
             self.last_tick_instant.insert(viewport_id, None);
@@ -274,6 +275,7 @@ impl StandalonePreviewApp {
                     crate::engine::tick_frame_view_zoom(es);
                     crate::engine::apply_frame_view_zoom(es);
                     crate::engine::tick_f3_menu(es);
+                    crate::engine::tick_overlay_red_pointer(es);
                     frame_data.rgba.copy_from_slice(es.frame.buffer_mut());
                 }
             }


### PR DESCRIPTION
1. add button to show and hide viewport for low-bandwidth performance retention.
2. add on-screen mouse pointer in the f3 layer for when we access through that way
3. mesh mode changes for LAN and Online and Off selectors.
4. events are smooth for controlling the iOS from my laptop.